### PR TITLE
Safari only has .children defined on HTML elements

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -135,7 +135,7 @@ DOMPurify.sanitize = function(a){
             currentNode.parentNode.removeChild(currentNode);
             return true;
         }
-        if(SAFE_FOR_JQUERY && currentNode.children.length === 0){
+        if(SAFE_FOR_JQUERY && !currentNode.firstElementChild){
             currentNode.textContent
                 = currentNode.textContent.replace(/\/+>/g, '>');
         }


### PR DESCRIPTION
Safari only has .children defined on HTML elements. To detect element content I'm using firstElementChild instead. This fixes an error in Safari 7.
