### PR TITLE
Fixes bug in IE, where all attributes have empty value after sanitizing.

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -170,9 +170,10 @@ DOMPurify.sanitize = function(dirty, cfg){
      * @return  void
      */
     var _sanitizeAttributes = function(currentNode){
-        var regex = /^(\w+script|data):/gi;
+        var regex = /^(\w+script|data):/gi,
+            clonedNode = currentNode.cloneNode();
         for(var attr = currentNode.attributes.length-1; attr>=0; attr--){
-            var tmp  = currentNode.attributes[attr];
+            var tmp  = clonedNode.attributes[attr];
             currentNode.removeAttribute(currentNode.attributes[attr].name);
             if(tmp instanceof Attr) {
                 if((ALLOWED_ATTR.indexOf(tmp.name.toLowerCase()) > -1 || 


### PR DESCRIPTION
In `_sanitizeAttributes`, the attribute is referenced in a variable
(`tmp`) and removed from `currentNode`.
In IE, after the attribute is removed from `currentNode`, the value in
`tmp` variable is also removed. So instead of just getting the attribute
from `currentNode`, clone `currentNode` and get the attribute from the
`clonedNode`.
