### PR TITLE
Adjust export for Common.js Node-like environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ You can also grab the files straight from NPM:
 npm install dompurify
 ```
 
+```javascript
+var DOMPurify = require('dompurify');
+var clean = DOMPurify.sanitize(dirty);
+```
+
 ## Is there a demo?
 
 Of course there is a demo! [Play with DOMPurify](https://cure53.de/purify)

--- a/purify.js
+++ b/purify.js
@@ -4,6 +4,8 @@
     'use strict';
     if (typeof define === "function" && define.amd) {
         define(factory);
+    } else if (typeof module !== "undefined") {
+        module.exports = factory();
     } else {
         root.DOMPurify = factory();
     }


### PR DESCRIPTION
Currently, when you require **DOMPurify** in Node.js environments or similar (like Browserify) an object containing `DOMPurify` is being exported and not the `DOMPurify` object itself. This small change allows this cleaner require: 

``` javascript
var DOMPurify = require('dompurify');
```

Instead of the current:

``` javascript
var DOMPurify = require('dompurify').DOMPurify;
```

Here's a working example on RequireBin: http://requirebin.com/?gist=a597860855d59cadfaeb
