### PR TITLE
Fall back to toStaticHTML if available

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -403,6 +403,9 @@
         
         /* Feature check and untouched opt-out return */
         if(typeof document.implementation.createHTMLDocument === 'undefined') {
+            if (window.toStaticHTML !== 'undefined' && typeof dirty === 'string') {
+                return window.toStaticHTML(dirty);
+            }
             return dirty;    
         }               
 


### PR DESCRIPTION
85de1e83b9ea22ec7e6cb379efc21d0d4ec83478 added a feature detect to not do anything if createHTMLDocument does not exist. IE8 is likely one of the most common browsers that doesn't have createHTMLDocument. This diff modifies code to use toStaticHTML which IE8 supports. Despite its limitations, this is better than doing nothing.
