### PR TITLE
Optimise and refine

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -326,7 +326,6 @@
             ) {
                 /* Keep content for white-listed elements */
                 if (KEEP_CONTENT && currentNode.insertAdjacentHTML
-                    && currentNode.nodeName.toLowerCase
                     && CONTENT_TAGS.indexOf(tagName) !== -1){
                     try {
                         currentNode.insertAdjacentHTML('AfterEnd', currentNode.innerHTML);

--- a/purify.js
+++ b/purify.js
@@ -352,7 +352,7 @@
          * _sanitizeAttributes
          *
          * @protect attributes
-         * @protect removeAttribiuteNode
+         * @protect removeAttributeNode
          * @protect setAttribute
          * @protect cloneNode
          *

--- a/purify.js
+++ b/purify.js
@@ -475,7 +475,7 @@
         cfg ? _parseConfig(cfg) : null;
 
         /* Exit directly if we have nothing to do */
-        if (dirty.indexOf('<') === -1) {
+        if (!RETURN_DOM && !WHOLE_DOCUMENT && dirty.indexOf('<') === -1) {
             return dirty;
         }
 

--- a/purify.js
+++ b/purify.js
@@ -321,8 +321,7 @@
             });
 
             /* Remove element if anything forbids its presence */
-            if (currentNode.nodeType === currentNode.COMMENT_NODE
-                || ALLOWED_TAGS.indexOf(tagName) === -1
+            if (ALLOWED_TAGS.indexOf(tagName) === -1
                 || FORBID_TAGS.indexOf(tagName) > -1
             ) {
                 /* Keep content for white-listed elements */

--- a/purify.js
+++ b/purify.js
@@ -243,22 +243,23 @@
     var _initDocument = function(dirty) {
         /* Create documents to map markup to */
         var dom = document.implementation.createHTMLDocument('');
-            dom.body.parentNode.removeChild(dom.body.parentNode.firstElementChild);
-            dom.body.outerHTML = dirty;
+        var freshdom, doc;
+
+        /* Set content */
+        var body = dom.body;
+        body.parentNode.removeChild(body.parentNode.firstElementChild);
+        body.outerHTML = dirty;
 
         /* Work on whole document or just its body */
-        var body = WHOLE_DOCUMENT ? dom.body.parentNode : dom.body;
-        if (
-            !(dom.body instanceof HTMLBodyElement) ||
-            !(dom.body instanceof HTMLHtmlElement)
-        ) {
-            var doc = (typeof HTMLTemplateElement === 'function') ?
+        body = WHOLE_DOCUMENT ? dom.body.parentNode : dom.body;
+        if (!(body instanceof (WHOLE_DOCUMENT ? HTMLHtmlElement : HTMLBodyElement))) {
+            doc = (typeof HTMLTemplateElement === 'function') ?
                 document.createElement('template').content.ownerDocument :
                 document;
-            var freshdom = doc.implementation.createHTMLDocument('');
-            body = WHOLE_DOCUMENT
-                ? freshdom.getElementsByTagName.call(dom,'html')[0]
-                : freshdom.getElementsByTagName.call(dom,'body')[0];
+            freshdom = doc.implementation.createHTMLDocument('');
+            body = WHOLE_DOCUMENT ?
+                freshdom.getElementsByTagName.call(dom,'html')[0] :
+                freshdom.getElementsByTagName.call(dom,'body')[0];
         }
         return body;
     };

--- a/purify.js
+++ b/purify.js
@@ -201,11 +201,6 @@
          * @return a DOM, filled with the dirty markup
          */
         var _initDocument = function(dirty) {
-            /* Exit directly if we have nothing to do */
-            if (typeof dirty === 'string' && dirty.indexOf('<') === -1) {
-                return dirty;
-            }
-
             /* Create documents to map markup to */
             var dom = document.implementation.createHTMLDocument('');
                 dom.body.parentNode.removeChild(dom.body.parentNode.firstElementChild);
@@ -479,12 +474,17 @@
         /* Assign config vars */
         cfg ? _parseConfig(cfg) : null;
 
+        /* Exit directly if we have nothing to do */
+        if (dirty.indexOf('<') === -1) {
+            return dirty;
+        }
+
         /* Initialize the document to work on */
         var body = _initDocument(dirty);
 
-        /* Early exit in case document is empty */
-        if (typeof body !== 'object') {
-            return body ? body : '';
+        /* Check we have a DOM node from the data */
+        if (!body) {
+            return RETURN_DOM ? null : '';
         }
 
         /* Get node iterator */

--- a/purify.js
+++ b/purify.js
@@ -16,11 +16,11 @@
     var hooks = {};
 
     /**
-     * Version label, exposed for easier checks 
+     * Version label, exposed for easier checks
      * if DOMPurfy is up to date or not
      */
     DOMPurify.version = '0.6.2';
-    
+
     /**
      * sanitize
      * Public method providing core sanitation functionality
@@ -122,10 +122,10 @@
             // XML
             'xlink:href','xml:id','xlink:title','xml:space'
         ];
-        
+
         /* Explicitly forbidden attributes (overrides ALLOWED_ATTR/ADD_ATTR) */
         var FORBID_ATTR = [];
-        
+
         /* Explicitly forbidden tags (overrides ALLOWED_TAGS/ADD_TAGS) */
         var FORBID_TAGS = [];
 
@@ -167,7 +167,6 @@
          * @param  optional config literal
          */
         var _parseConfig = function(cfg) {
-
             /* Shield configuration object from tampering */
             if (typeof cfg !== 'object') {
                 cfg = {};
@@ -189,7 +188,7 @@
             /* Merge configuration parameters */
             cfg.ADD_ATTR ? ALLOWED_ATTR = ALLOWED_ATTR.concat(cfg.ADD_ATTR) : null;
             cfg.ADD_TAGS ? ALLOWED_TAGS = ALLOWED_TAGS.concat(cfg.ADD_TAGS) : null;
-            
+
             /* Add #text in case KEEP_CONTENT is set to true */
             KEEP_CONTENT ? ALLOWED_TAGS.push('#text') : null;
 
@@ -205,7 +204,6 @@
          * @return a DOM, filled with the dirty markup
          */
         var _initDocument = function(dirty) {
-
             /* Exit directly if we have nothing to do */
             if (typeof dirty === 'string' && dirty.indexOf('<') === -1) {
                 return dirty;
@@ -300,18 +298,16 @@
          * @return  true if node was killed, false if left alive
          */
         var _sanitizeElements = function(currentNode) {
-
             /* Execute a hook if present */
             _executeHook('beforeSanitizeElements', currentNode, null);
 
             /* Check if element is clobbered or can clobber */
             if (_isClobbered(currentNode)) {
-
                 /* Be harsh with clobbered content, element has to go! */
-                try{
+                try {
                     currentNode.parentNode.removeChild(currentNode);
-                } catch(e){
-                    currentNode.outerHTML='';
+                } catch (e) {
+                    currentNode.outerHTML = '';
                 }
                 return true;
             }
@@ -328,14 +324,14 @@
                 || ALLOWED_TAGS.indexOf(tagName) === -1
                 || FORBID_TAGS.indexOf(tagName) > -1
             ) {
-                
+
                 /* Keep content for white-listed elements */
                 if (KEEP_CONTENT && currentNode.insertAdjacentHTML
                     && currentNode.nodeName.toLowerCase
                     && CONTENT_TAGS.indexOf(tagName) !== -1){
                     try {
                         currentNode.insertAdjacentHTML('AfterEnd', currentNode.innerHTML);
-                    } catch(e) {}
+                    } catch (e) {}
                 }
 
                 /* Remove element if anything permits its presence */
@@ -366,10 +362,9 @@
          * @return  void
          */
         var _sanitizeAttributes = function(currentNode) {
-        
             /* Execute a hook if present */
             _executeHook('beforeSanitizeAttributes', currentNode, null);
-                    
+
             var regex = /^(\w+script|data):/gi,
                 clonedNode = currentNode.cloneNode(true),
                 tmp, clobbering;
@@ -382,15 +377,14 @@
 
             /* Go backwards over all attributes; safely remove bad ones */
             for (var attr = currentNode.attributes.length-1; attr >= 0; attr--) {
-
                 tmp = clonedNode.attributes[attr];
                 clobbering = false;
                 currentNode.removeAttribute(currentNode.attributes[attr].name);
 
                 if (!tmp instanceof Attr) { continue; }
 
-                if(SANITIZE_DOM) {
-                    if((tmp.name === 'id' || tmp.name === 'name')
+                if (SANITIZE_DOM) {
+                    if ((tmp.name === 'id' || tmp.name === 'name')
                         && (tmp.value in window || tmp.value in document)) {
                         clobbering = true;
                     }
@@ -401,7 +395,7 @@
                 /* Execute a hook if present */
                 _executeHook('uponSanitizeAttribute', currentNode, {
                     attrName: attrName, attrValue: tmp.value, attr: tmp
-                });                
+                });
 
                 if (
                     ((ALLOWED_ATTR.indexOf(attrName) > -1 &&
@@ -439,14 +433,13 @@
         var _sanitizeShadowDOM = function(fragment) {
             var shadowNode;
             var shadowIterator = _createIterator(fragment);
-            
+
             /* Execute a hook if present */
-            _executeHook('beforeSanitizeShadowDOM', fragment, null);            
+            _executeHook('beforeSanitizeShadowDOM', fragment, null);
 
             while (shadowNode = shadowIterator.nextNode()) {
-                
                 /* Execute a hook if present */
-                _executeHook('uponSanitizeShadowNode', shadowNode, null);                 
+                _executeHook('uponSanitizeShadowNode', shadowNode, null);
 
                 /* Sanitize tags and elements */
                 if (_sanitizeElements(shadowNode)) {
@@ -461,9 +454,9 @@
                 /* Check attributes, sanitize if necessary */
                 _sanitizeAttributes(shadowNode);
             }
-            
+
             /* Execute a hook if present */
-            _executeHook('afterSanitizeShadowDOM', fragment, null); 
+            _executeHook('afterSanitizeShadowDOM', fragment, null);
         };
 
         /**
@@ -536,7 +529,6 @@
      * @param {Function} hookFunction
      */
     DOMPurify.addHook = function(entryPoint, hookFunction) {
-
         if (typeof hookFunction !== 'function') { return; }
         hooks[entryPoint] = hooks[entryPoint] || [];
         hooks[entryPoint].push(hookFunction);

--- a/purify.js
+++ b/purify.js
@@ -25,7 +25,7 @@
      * sanitize
      * Public method providing core sanitation functionality
      *
-     * @param {mixed}  dirty string or DOM
+     * @param {String} dirty string
      * @param {Object} configuration object
      */
     DOMPurify.sanitize = function(dirty, cfg) {

--- a/purify.js
+++ b/purify.js
@@ -320,11 +320,11 @@
                 tagName: tagName
             });
 
+            /* Remove element if anything forbids its presence */
             if (currentNode.nodeType === currentNode.COMMENT_NODE
                 || ALLOWED_TAGS.indexOf(tagName) === -1
                 || FORBID_TAGS.indexOf(tagName) > -1
             ) {
-
                 /* Keep content for white-listed elements */
                 if (KEEP_CONTENT && currentNode.insertAdjacentHTML
                     && currentNode.nodeName.toLowerCase
@@ -333,8 +333,6 @@
                         currentNode.insertAdjacentHTML('AfterEnd', currentNode.innerHTML);
                     } catch (e) {}
                 }
-
-                /* Remove element if anything permits its presence */
                 currentNode.parentNode.removeChild(currentNode);
                 return true;
             }

--- a/purify.js
+++ b/purify.js
@@ -22,6 +22,13 @@
     DOMPurify.version = '0.6.2';
 
     /**
+     * Expose whether this browser supports running the full DOMPurify.
+     */
+    DOMPurify.isSupported =
+        typeof document.implementation.createHTMLDocument !== 'undefined' &&
+        document.documentMode !== 9;
+
+    /**
      * sanitize
      * Public method providing core sanitation functionality
      *
@@ -462,9 +469,8 @@
             });
         };
 
-        /* Feature check and untouched opt-out return */
-        if (typeof document.implementation.createHTMLDocument === 'undefined'
-            || (typeof document.documentMode === 'number' && document.documentMode === 9)) {
+        /* Check we can run. Otherwise fall back or ignore */
+        if (!DOMPurify.isSupported) {
             if (typeof window.toStaticHTML === 'function' && typeof dirty === 'string') {
                 return window.toStaticHTML(dirty);
             }

--- a/purify.js
+++ b/purify.js
@@ -156,8 +156,6 @@
             'tfoot','th','thead','time','tr','tt','u','ul','var'
         ];
 
-        var DEBUG_OUTPUT = false;
-
         /* Ideally, do not touch anything below this line */
         /* ______________________________________________ */
 
@@ -183,7 +181,6 @@
             'RETURN_DOM'      in cfg ? RETURN_DOM      = cfg.RETURN_DOM      : null;
             'SANITIZE_DOM'    in cfg ? SANITIZE_DOM    = cfg.SANITIZE_DOM    : null;
             'KEEP_CONTENT'    in cfg ? KEEP_CONTENT    = cfg.KEEP_CONTENT    : null;
-            'DEBUG_OUTPUT'    in cfg ? DEBUG_OUTPUT    = cfg.DEBUG_OUTPUT    : null;
 
             /* Merge configuration parameters */
             cfg.ADD_ATTR ? ALLOWED_ATTR = ALLOWED_ATTR.concat(cfg.ADD_ATTR) : null;

--- a/purify.js
+++ b/purify.js
@@ -15,15 +15,6 @@
     var DOMPurify = {};
     var hooks = {};
 
-    /* Add properties to a lookup table */
-    var _addToSet = function(set, array) {
-        var l = array.length;
-        while (l--) {
-            set[array[l]] = true;
-        }
-        return set;
-    };
-
     /**
      * Version label, exposed for easier checks
      * if DOMPurfy is up to date or not
@@ -37,6 +28,477 @@
         typeof document.implementation.createHTMLDocument !== 'undefined' &&
         document.documentMode !== 9;
 
+    /* Add properties to a lookup table */
+    var _addToSet = function(set, array) {
+        var l = array.length;
+        while (l--) {
+            set[array[l]] = true;
+        }
+        return set;
+    };
+
+    /* Shallow clone an object */
+    var _cloneObj = function(object) {
+        var newObject = {};
+        var property;
+        for (property in object) {
+            if (object.hasOwnProperty(property)) {
+                newObject[property] = object[property];
+            }
+        }
+        return newObject;
+    };
+
+    /**
+     * We consider the elements and attributes below to be safe. Ideally
+     * don't add any new ones but feel free to remove unwanted ones.
+     */
+
+    /* allowed element names */
+    var ALLOWED_TAGS = null;
+    var DEFAULT_ALLOWED_TAGS = _addToSet({}, [
+
+        // HTML
+        'a','abbr','acronym','address','area','article','aside','audio','b',
+        'bdi','bdo','big','blink','blockquote','body','br','button','canvas',
+        'caption','center','cite','code','col','colgroup','content','data',
+        'datalist','dd','decorator','del','details','dfn','dir','div','dl','dt',
+        'element','em','fieldset','figcaption','figure','font','footer','form',
+        'h1','h2','h3','h4','h5','h6','head','header','hgroup','hr','html','i',
+        'img','input','ins','kbd','label','legend','li','main','map','mark',
+        'marquee','menu','menuitem','meter','nav','nobr','ol','optgroup',
+        'option','output','p','pre','progress','q','rp','rt','ruby','s','samp',
+        'section','select','shadow','small','source','spacer','span','strike',
+        'strong','style','sub','summary','sup','table','tbody','td','template',
+        'textarea','tfoot','th','thead','time','tr','track','tt','u','ul','var',
+        'video','wbr',
+
+        // SVG
+        'svg','altglyph','altglyphdef','altglyphitem','animatecolor',
+        'animatemotion','animatetransform','circle','clippath','defs','desc',
+        'ellipse','font','g','glyph','glyphref','hkern','image','line',
+        'lineargradient','marker','mask','metadata','mpath','path','pattern',
+        'polygon','polyline','radialgradient','rect','stop','switch','symbol',
+        'text','textpath','title','tref','tspan','view','vkern',
+
+        //MathML
+        'math','menclose','merror','mfenced','mfrac','mglyph','mi','mlabeledtr',
+        'mmuliscripts','mn','mo','mover','mpadded','mphantom','mroot','mrow',
+        'ms','mpspace','msqrt','mystyle','msub','msup','msubsup','mtable','mtd',
+        'mtext','mtr','munder','munderover',
+
+        //Text
+        '#text'
+    ]);
+
+    /* Allowed attribute names */
+    var ALLOWED_ATTR = null;
+    var DEFAULT_ALLOWED_ATTR = _addToSet({}, [
+
+        // HTML
+        'accept','action','align','alt','autocomplete','bgcolor','border',
+        'checked','cite','class','color','cols','colspan','coords','datetime',
+        'default','dir','disabled','download','enctype','for','headers','height',
+        'hidden','high','href','hreflang','id','ismap','label','lang','list',
+        'loop', 'low','max','maxlength','media','method','min','multiple',
+        'name','novalidate','open','optimum','pattern','placeholder','poster',
+        'preload','pubdate','radiogroup','readonly','rel','required','rev',
+        'reversed','rows','rowspan','spellcheck','scope','selected','shape',
+        'size','span','srclang','start','src','step','style','summary','tabindex',
+        'title','type','usemap','valign','value','width','xmlns',
+
+        // SVG
+        'accent-height','accumulate','additivive','alignment-baseline',
+        'ascent','azimuth','baseline-shift','bias','clip','clip-path',
+        'clip-rule','color','color-interpolation','color-interpolation-filters',
+        'color-profile','color-rendering','cx','cy','d','dy','dy','direction',
+        'display','divisor','dur','elevation','end','fill','fill-opacity',
+        'fill-rule','filter','flood-color','flood-opacity','font-family',
+        'font-size','font-size-adjust','font-stretch','font-style','font-variant',
+        'front-weight','image-rendering','in','in2','k1','k2','k3','k4','kerning',
+        'letter-spacing','lighting-color','local','marker-end','marker-mid',
+        'marker-start','max','mask','mode','min','operator','opacity','order',
+        'overflow','paint-order','path','points','r','rx','ry','radius','restart',
+        'scale','seed','shape-rendering','stop-color','stop-opacity',
+        'stroke-dasharray','stroke-dashoffset','stroke-linecap','stroke-linejoin',
+        'stroke-miterlimit','stroke-opacity','stroke','stroke-width','transform',
+        'text-anchor','text-decoration','text-rendering','u1','u2','viewbox',
+        'visibility','word-spacing','wrap','writing-mode','x','x1','x2','y',
+        'y1','y2','z',
+
+        // MathML
+        'accent','accentunder','bevelled','close','columnsalign','columnlines',
+        'columnspan','denomalign','depth','display','displaystyle','fence',
+        'frame','largeop','length','linethickness','lspace','lquote',
+        'mathbackground','mathcolor','mathsize','mathvariant','maxsize',
+        'minsize','movablelimits','notation','numalign','open','rowalign',
+        'rowlines','rowspacing','rowspan','rspace','rquote','scriptlevel',
+        'scriptminsize','scriptsizemultiplier','selection','separator',
+        'separators','stretchy','subscriptshift','supscriptshift','symmetric',
+        'voffset',
+
+        // XML
+        'xlink:href','xml:id','xlink:title','xml:space'
+    ]);
+
+    /* Explicitly forbidden tags (overrides ALLOWED_TAGS/ADD_TAGS) */
+    var FORBID_TAGS = null;
+
+    /* Explicitly forbidden attributes (overrides ALLOWED_ATTR/ADD_ATTR) */
+    var FORBID_ATTR = null;
+
+    /* Decide if custom data attributes are okay */
+    var ALLOW_DATA_ATTR = true;
+
+    /* Output should be safe for jQuery's $() factory? */
+    var SAFE_FOR_JQUERY = false;
+
+    /* Decide if document with <html>... should be returned */
+    var WHOLE_DOCUMENT = false;
+
+    /* Decide if a DOM node or a string should be returned */
+    var RETURN_DOM = false;
+
+    /* Output should be free from DOM clobbering attacks? */
+    var SANITIZE_DOM = true;
+
+    /* Keep element content when removing element? */
+    var KEEP_CONTENT = true;
+
+    /* Tags to keep content from (when KEEP_CONTENT is true) */
+    var CONTENT_TAGS = _addToSet({}, [
+        'a','abbr','acronym','address','article','aside','b','bdi','bdo',
+        'big','blink','blockquote','caption','center','cite','code','col',
+        'dd','del','details','dfn','dir','div','dl','dt','em','figcaption',
+        'figure','footer','h1','h2','h3','h4','h5','h6','header','i','ins',
+        'kbd','label','legend','li','main','mark','marquee','nav','ol',
+        'output','p','pre','q','rp','rt','ruby','s','samp','section','small',
+        'span','strike','strong','sub','summary','sup','table','tbody','td',
+        'tfoot','th','thead','time','tr','tt','u','ul','var'
+    ]);
+
+    /* Keep a reference to config to pass to hooks */
+    var CONFIG = null;
+
+    /* Ideally, do not touch anything below this line */
+    /* ______________________________________________ */
+
+    /**
+     * _parseConfig
+     *
+     * @param  optional config literal
+     */
+    var _parseConfig = function(cfg) {
+        /* Shield configuration object from tampering */
+        if (typeof cfg !== 'object') {
+            cfg = {};
+        }
+
+        /* Set configuration parameters */
+        ALLOWED_TAGS = 'ALLOWED_TAGS' in cfg ?
+            _addToSet({}, cfg.ALLOWED_TAGS) : DEFAULT_ALLOWED_TAGS;
+        ALLOWED_ATTR = 'ALLOWED_ATTR' in cfg ?
+            _addToSet({}, cfg.ALLOWED_ATTR) : DEFAULT_ALLOWED_ATTR;
+        FORBID_TAGS = 'FORBID_TAGS' in cfg ?
+            _addToSet({}, cfg.FORBID_TAGS) : {};
+        FORBID_ATTR = 'FORBID_ATTR' in cfg ?
+            _addToSet({}, cfg.FORBID_ATTR) : {};
+        ALLOW_DATA_ATTR = cfg.ALLOW_DATA_ATTR !== false; // Default true
+        SAFE_FOR_JQUERY = cfg.SAFE_FOR_JQUERY  || false; // Default false
+        WHOLE_DOCUMENT  = cfg.WHOLE_DOCUMENT   || false; // Default false
+        RETURN_DOM      = cfg.RETURN_DOM       || false; // Default false
+        SANITIZE_DOM    = cfg.SANITIZE_DOM    !== false; // Default true
+        KEEP_CONTENT    = cfg.KEEP_CONTENT    !== false; // Default true
+
+        /* Merge configuration parameters */
+        if (cfg.ADD_TAGS) {
+            if (ALLOWED_TAGS === DEFAULT_ALLOWED_TAGS) {
+                ALLOWED_TAGS = _cloneObj(ALLOWED_TAGS);
+            }
+            _addToSet(ALLOWED_TAGS, cfg.ADD_TAGS);
+        }
+        if (cfg.ADD_ATTR) {
+            if (ALLOWED_ATTR === DEFAULT_ALLOWED_ATTR) {
+                ALLOWED_ATTR = _cloneObj(ALLOWED_ATTR);
+            }
+            _addToSet(ALLOWED_ATTR, cfg.ADD_ATTR);
+        }
+
+        /* Add #text in case KEEP_CONTENT is set to true */
+        if (KEEP_CONTENT) { ALLOWED_TAGS['#text'] = true; }
+
+        // Prevent further manipulation of configuration.
+        // Not available in IE8, Safari 5, etc.
+        if (Object && 'freeze' in Object) { Object.freeze(cfg); }
+
+        CONFIG = cfg;
+    };
+
+   /**
+     * _initDocument
+     *
+     * @param  a string of dirty markup
+     * @return a DOM, filled with the dirty markup
+     */
+    var _initDocument = function(dirty) {
+        /* Create documents to map markup to */
+        var dom = document.implementation.createHTMLDocument('');
+            dom.body.parentNode.removeChild(dom.body.parentNode.firstElementChild);
+            dom.body.outerHTML = dirty;
+
+        /* Work on whole document or just its body */
+        var body = WHOLE_DOCUMENT ? dom.body.parentNode : dom.body;
+        if (
+            !(dom.body instanceof HTMLBodyElement) ||
+            !(dom.body instanceof HTMLHtmlElement)
+        ) {
+            var doc = (typeof HTMLTemplateElement === 'function') ?
+                document.createElement('template').content.ownerDocument :
+                document;
+            var freshdom = doc.implementation.createHTMLDocument('');
+            body = WHOLE_DOCUMENT
+                ? freshdom.getElementsByTagName.call(dom,'html')[0]
+                : freshdom.getElementsByTagName.call(dom,'body')[0];
+        }
+        return body;
+    };
+
+    /**
+     * _createIterator
+     *
+     * @param  document/fragment to create iterator for
+     * @return iterator instance
+     */
+    var _createIterator = function(doc) {
+        return document.createNodeIterator(
+            doc,
+            NodeFilter.SHOW_ELEMENT
+            | NodeFilter.SHOW_COMMENT
+            | NodeFilter.SHOW_TEXT,
+            function() { return NodeFilter.FILTER_ACCEPT; },
+            false
+        );
+    };
+
+    /**
+     * _isClobbered
+     *
+     * @param  element to check for clobbering attacks
+     * @return true if clobbered, false if safe
+     */
+    var _isClobbered = function(elm) {
+        if (elm instanceof Text) {
+            return false;
+        }
+        if (
+            (elm.children && !(elm.children instanceof HTMLCollection))
+            || (elm.attributes instanceof HTMLCollection)
+            || (elm.attributes instanceof NodeList)
+            || (elm.insertAdjacentHTML && typeof elm.insertAdjacentHTML !== 'function')
+            || (elm.outerHTML && typeof elm.outerHTML !== 'string')
+            || typeof elm.nodeName !== 'string'
+            || typeof elm.textContent !== 'string'
+            || typeof elm.nodeType !== 'number'
+            || typeof elm.COMMENT_NODE !== 'number'
+            || typeof elm.setAttribute !== 'function'
+            || typeof elm.hasAttribute !== 'function'
+            || typeof elm.cloneNode !== 'function'
+            || typeof elm.removeAttributeNode !== 'function'
+            || typeof elm.removeChild !== 'function'
+            || typeof elm.attributes.item !== 'function'
+            || (elm.id === 'createElement' || elm.name === 'createElement')
+            || (elm.id === 'implementation' || elm.name === 'implementation')
+            || (elm.id === 'createNodeIterator' || elm.name === 'createNodeIterator')
+        ) {
+            return true;
+        }
+        return false;
+    };
+
+    /**
+     * _sanitizeElements
+     *
+     * @protect removeChild
+     * @protect nodeType
+     * @protect nodeName
+     * @protect textContent
+     * @protect outerHTML
+     * @protect currentNode
+     * @protect insertAdjacentHTML
+     *
+     * @param   node to check for permission to exist
+     * @return  true if node was killed, false if left alive
+     */
+    var _sanitizeElements = function(currentNode) {
+        /* Execute a hook if present */
+        _executeHook('beforeSanitizeElements', currentNode, null);
+
+        /* Check if element is clobbered or can clobber */
+        if (_isClobbered(currentNode)) {
+            /* Be harsh with clobbered content, element has to go! */
+            try {
+                currentNode.parentNode.removeChild(currentNode);
+            } catch (e) {
+                currentNode.outerHTML = '';
+            }
+            return true;
+        }
+
+        /* Now let's check the element's type and name */
+        var tagName = currentNode.nodeName.toLowerCase();
+
+        /* Execute a hook if present */
+        _executeHook('uponSanitizeElement', currentNode, {
+            tagName: tagName
+        });
+
+        /* Remove element if anything forbids its presence */
+        if (!ALLOWED_TAGS[tagName] || FORBID_TAGS[tagName]) {
+            /* Keep content for white-listed elements */
+            if (KEEP_CONTENT && currentNode.insertAdjacentHTML
+                && CONTENT_TAGS[tagName]){
+                try {
+                    currentNode.insertAdjacentHTML('AfterEnd', currentNode.innerHTML);
+                } catch (e) {}
+            }
+            currentNode.parentNode.removeChild(currentNode);
+            return true;
+        }
+
+        /* Finally, convert markup to cover jQuery behavior */
+        if (SAFE_FOR_JQUERY && !currentNode.firstElementChild) {
+            currentNode.innerHTML = currentNode.textContent.replace(/</g, '&lt;');
+        }
+
+        /* Execute a hook if present */
+        _executeHook('afterSanitizeElements', currentNode, null);
+
+        return false;
+    };
+
+    /**
+     * _sanitizeAttributes
+     *
+     * @protect attributes
+     * @protect removeAttributeNode
+     * @protect setAttribute
+     * @protect cloneNode
+     *
+     * @param   node to sanitize
+     * @return  void
+     */
+    var _sanitizeAttributes = function(currentNode) {
+        /* Execute a hook if present */
+        _executeHook('beforeSanitizeAttributes', currentNode, null);
+
+        var isScriptOrData = /^(?:\w+script|data):/gi,
+            clonedNode = currentNode.cloneNode(false),
+            tmp, clobbering;
+
+        /* This needs to be extensive thanks to Webkit/Blink's behavior */
+        var whitespace = /[\x00-\x20\xA0\u1680\u180E\u2000-\u2029\u205f\u3000]/g;
+
+        /* Check if we have attributes; if not we might have a text node */
+        if (!currentNode.attributes) { return; }
+
+        /* Go backwards over all attributes; safely remove bad ones */
+        for (var attr = currentNode.attributes.length-1; attr >= 0; attr--) {
+            tmp = clonedNode.attributes[attr];
+            clobbering = false;
+            currentNode.removeAttribute(currentNode.attributes[attr].name);
+
+            if (!tmp instanceof Attr) { continue; }
+
+            if (SANITIZE_DOM) {
+                if ((tmp.name === 'id' || tmp.name === 'name')
+                    && (tmp.value in window || tmp.value in document)) {
+                    clobbering = true;
+                }
+            }
+            /* Safely handle attributes */
+            var attrName = tmp.name.toLowerCase();
+
+            /* Execute a hook if present */
+            _executeHook('uponSanitizeAttribute', currentNode, {
+                attrName: attrName, attrValue: tmp.value, attr: tmp
+            });
+
+            if (
+                ((ALLOWED_ATTR[attrName] && !FORBID_ATTR[attrName]) ||
+                 (ALLOW_DATA_ATTR && /^data-[\w-]+/i.test(tmp.name)))
+
+                /* Get rid of script and data URIs */
+                && (!isScriptOrData.test(tmp.value.replace(whitespace,''))
+
+                    /* Keep image data URIs alive if src is allowed */
+                    || (tmp.name === 'src'
+                        && tmp.value.indexOf('data:') === 0
+                        && currentNode.nodeName === 'IMG'))
+
+                /* Make sure attribute cannot clobber */
+                && !clobbering
+            ) {
+                /* Handle invalid data attribute set by try-catching it */
+                try {
+                    currentNode.setAttribute(tmp.name, tmp.value);
+                } catch (e) {}
+            }
+        }
+
+        /* Execute a hook if present */
+        _executeHook('afterSanitizeAttributes', currentNode, null);
+    };
+
+    /**
+     * _sanitizeShadowDOM
+     *
+     * @param  fragment to iterate over recursively
+     * @return void
+     */
+    var _sanitizeShadowDOM = function(fragment) {
+        var shadowNode;
+        var shadowIterator = _createIterator(fragment);
+
+        /* Execute a hook if present */
+        _executeHook('beforeSanitizeShadowDOM', fragment, null);
+
+        while (shadowNode = shadowIterator.nextNode()) {
+            /* Execute a hook if present */
+            _executeHook('uponSanitizeShadowNode', shadowNode, null);
+
+            /* Sanitize tags and elements */
+            if (_sanitizeElements(shadowNode)) {
+                continue;
+            }
+
+            /* Deep shadow DOM detected */
+            if (shadowNode.content instanceof DocumentFragment) {
+                _sanitizeShadowDOM(shadowNode.content);
+            }
+
+            /* Check attributes, sanitize if necessary */
+            _sanitizeAttributes(shadowNode);
+        }
+
+        /* Execute a hook if present */
+        _executeHook('afterSanitizeShadowDOM', fragment, null);
+    };
+
+    /**
+     * _executeHook
+     * Execute user configurable hooks
+     *
+     * @param  {String} entryPoint  Name of the hook's entry point
+     * @param  {Node} currentNode
+     */
+    var _executeHook = function(entryPoint, currentNode, data) {
+        if (!hooks[entryPoint]) { return; }
+
+        hooks[entryPoint].forEach(function(hook) {
+            hook.call(DOMPurify, currentNode, data, CONFIG);
+        });
+    };
+
     /**
      * sanitize
      * Public method providing core sanitation functionality
@@ -45,440 +507,6 @@
      * @param {Object} configuration object
      */
     DOMPurify.sanitize = function(dirty, cfg) {
-
-        /**
-         * We consider the elements and attributes below to be safe. Ideally
-         * don't add any new ones but feel free to remove unwanted ones.
-         */
-
-        /* allowed element names */
-        var ALLOWED_TAGS = _addToSet({}, [
-
-            // HTML
-            'a','abbr','acronym','address','area','article','aside','audio','b',
-            'bdi','bdo','big','blink','blockquote','body','br','button','canvas',
-            'caption','center','cite','code','col','colgroup','content','data',
-            'datalist','dd','decorator','del','details','dfn','dir','div','dl','dt',
-            'element','em','fieldset','figcaption','figure','font','footer','form',
-            'h1','h2','h3','h4','h5','h6','head','header','hgroup','hr','html','i',
-            'img','input','ins','kbd','label','legend','li','main','map','mark',
-            'marquee','menu','menuitem','meter','nav','nobr','ol','optgroup',
-            'option','output','p','pre','progress','q','rp','rt','ruby','s','samp',
-            'section','select','shadow','small','source','spacer','span','strike',
-            'strong','style','sub','summary','sup','table','tbody','td','template',
-            'textarea','tfoot','th','thead','time','tr','track','tt','u','ul','var',
-            'video','wbr',
-
-            // SVG
-            'svg','altglyph','altglyphdef','altglyphitem','animatecolor',
-            'animatemotion','animatetransform','circle','clippath','defs','desc',
-            'ellipse','font','g','glyph','glyphref','hkern','image','line',
-            'lineargradient','marker','mask','metadata','mpath','path','pattern',
-            'polygon','polyline','radialgradient','rect','stop','switch','symbol',
-            'text','textpath','title','tref','tspan','view','vkern',
-
-            //MathML
-            'math','menclose','merror','mfenced','mfrac','mglyph','mi','mlabeledtr',
-            'mmuliscripts','mn','mo','mover','mpadded','mphantom','mroot','mrow',
-            'ms','mpspace','msqrt','mystyle','msub','msup','msubsup','mtable','mtd',
-            'mtext','mtr','munder','munderover',
-
-            //Text
-            '#text'
-        ]);
-
-        /* Decide if custom data attributes are okay */
-        var ALLOW_DATA_ATTR = true;
-
-        /* Allowed attribute names */
-        var ALLOWED_ATTR = _addToSet({}, [
-
-            // HTML
-            'accept','action','align','alt','autocomplete','bgcolor','border',
-            'checked','cite','class','color','cols','colspan','coords','datetime',
-            'default','dir','disabled','download','enctype','for','headers','height',
-            'hidden','high','href','hreflang','id','ismap','label','lang','list',
-            'loop', 'low','max','maxlength','media','method','min','multiple',
-            'name','novalidate','open','optimum','pattern','placeholder','poster',
-            'preload','pubdate','radiogroup','readonly','rel','required','rev',
-            'reversed','rows','rowspan','spellcheck','scope','selected','shape',
-            'size','span','srclang','start','src','step','style','summary','tabindex',
-            'title','type','usemap','valign','value','width','xmlns',
-
-            // SVG
-            'accent-height','accumulate','additivive','alignment-baseline',
-            'ascent','azimuth','baseline-shift','bias','clip','clip-path',
-            'clip-rule','color','color-interpolation','color-interpolation-filters',
-            'color-profile','color-rendering','cx','cy','d','dy','dy','direction',
-            'display','divisor','dur','elevation','end','fill','fill-opacity',
-            'fill-rule','filter','flood-color','flood-opacity','font-family',
-            'font-size','font-size-adjust','font-stretch','font-style','font-variant',
-            'front-weight','image-rendering','in','in2','k1','k2','k3','k4','kerning',
-            'letter-spacing','lighting-color','local','marker-end','marker-mid',
-            'marker-start','max','mask','mode','min','operator','opacity','order',
-            'overflow','paint-order','path','points','r','rx','ry','radius','restart',
-            'scale','seed','shape-rendering','stop-color','stop-opacity',
-            'stroke-dasharray','stroke-dashoffset','stroke-linecap','stroke-linejoin',
-            'stroke-miterlimit','stroke-opacity','stroke','stroke-width','transform',
-            'text-anchor','text-decoration','text-rendering','u1','u2','viewbox',
-            'visibility','word-spacing','wrap','writing-mode','x','x1','x2','y',
-            'y1','y2','z',
-
-            // MathML
-            'accent','accentunder','bevelled','close','columnsalign','columnlines',
-            'columnspan','denomalign','depth','display','displaystyle','fence',
-            'frame','largeop','length','linethickness','lspace','lquote',
-            'mathbackground','mathcolor','mathsize','mathvariant','maxsize',
-            'minsize','movablelimits','notation','numalign','open','rowalign',
-            'rowlines','rowspacing','rowspan','rspace','rquote','scriptlevel',
-            'scriptminsize','scriptsizemultiplier','selection','separator',
-            'separators','stretchy','subscriptshift','supscriptshift','symmetric',
-            'voffset',
-
-            // XML
-            'xlink:href','xml:id','xlink:title','xml:space'
-        ]);
-
-        /* Explicitly forbidden attributes (overrides ALLOWED_ATTR/ADD_ATTR) */
-        var FORBID_ATTR = {};
-
-        /* Explicitly forbidden tags (overrides ALLOWED_TAGS/ADD_TAGS) */
-        var FORBID_TAGS = {};
-
-        /* Decide if document with <html>... should be returned */
-        var WHOLE_DOCUMENT = false;
-
-        /* Decide if a DOM node or a string should be returned */
-        var RETURN_DOM = false;
-
-        /* Output should be safe for jQuery's $() factory? */
-        var SAFE_FOR_JQUERY = false;
-
-        /* Output should be free from DOM clobbering attacks? */
-        var SANITIZE_DOM = true;
-
-        /* Keep element content when removing element? */
-        var KEEP_CONTENT = true;
-
-        /* Tags to keep content from (when KEEP_CONTENT is true) */
-        var CONTENT_TAGS = _addToSet({}, [
-            'a','abbr','acronym','address','article','aside','b','bdi','bdo',
-            'big','blink','blockquote','caption','center','cite','code','col',
-            'dd','del','details','dfn','dir','div','dl','dt','em','figcaption',
-            'figure','footer','h1','h2','h3','h4','h5','h6','header','i','ins',
-            'kbd','label','legend','li','main','mark','marquee','nav','ol',
-            'output','p','pre','q','rp','rt','ruby','s','samp','section','small',
-            'span','strike','strong','sub','summary','sup','table','tbody','td',
-            'tfoot','th','thead','time','tr','tt','u','ul','var'
-        ]);
-
-        /* Ideally, do not touch anything below this line */
-        /* ______________________________________________ */
-
-        /**
-         * _parseConfig
-         *
-         * @param  optional config literal
-         */
-        var _parseConfig = function(cfg) {
-            /* Shield configuration object from tampering */
-            if (typeof cfg !== 'object') {
-                cfg = {};
-            }
-
-            /* Set configuration parameters */
-            'ALLOWED_ATTR'    in cfg ? ALLOWED_ATTR    = _addToSet({}, cfg.ALLOWED_ATTR) : null;
-            'ALLOWED_TAGS'    in cfg ? ALLOWED_TAGS    = _addToSet({}, cfg.ALLOWED_TAGS) : null;
-            'FORBID_ATTR'     in cfg ? FORBID_ATTR     = _addToSet({}, cfg.FORBID_ATTR)  : null;
-            'FORBID_TAGS'     in cfg ? FORBID_TAGS     = _addToSet({}, cfg.FORBID_TAGS)  : null;
-            'ALLOW_DATA_ATTR' in cfg ? ALLOW_DATA_ATTR = cfg.ALLOW_DATA_ATTR             : null;
-            'SAFE_FOR_JQUERY' in cfg ? SAFE_FOR_JQUERY = cfg.SAFE_FOR_JQUERY             : null;
-            'WHOLE_DOCUMENT'  in cfg ? WHOLE_DOCUMENT  = cfg.WHOLE_DOCUMENT              : null;
-            'RETURN_DOM'      in cfg ? RETURN_DOM      = cfg.RETURN_DOM                  : null;
-            'SANITIZE_DOM'    in cfg ? SANITIZE_DOM    = cfg.SANITIZE_DOM                : null;
-            'KEEP_CONTENT'    in cfg ? KEEP_CONTENT    = cfg.KEEP_CONTENT                : null;
-
-            /* Merge configuration parameters */
-            if (cfg.ADD_TAGS) {
-                _addToSet(ALLOWED_TAGS, cfg.ADD_TAGS);
-            }
-            if (cfg.ADD_ATTR) {
-                _addToSet(ALLOWED_ATTR, cfg.ADD_ATTR);
-            }
-
-            /* Add #text in case KEEP_CONTENT is set to true */
-            if (KEEP_CONTENT) { ALLOWED_TAGS['#text'] = true; }
-
-            // Prevent further manipulation of configuration.
-            // Not available in IE8, Safari 5, etc.
-            if (Object && 'freeze' in Object) { Object.freeze(cfg); }
-        };
-
-       /**
-         * _initDocument
-         *
-         * @param  a string of dirty markup
-         * @return a DOM, filled with the dirty markup
-         */
-        var _initDocument = function(dirty) {
-            /* Create documents to map markup to */
-            var dom = document.implementation.createHTMLDocument('');
-                dom.body.parentNode.removeChild(dom.body.parentNode.firstElementChild);
-                dom.body.outerHTML = dirty;
-
-            /* Work on whole document or just its body */
-            var body = WHOLE_DOCUMENT ? dom.body.parentNode : dom.body;
-            if (
-                !(dom.body instanceof HTMLBodyElement) ||
-                !(dom.body instanceof HTMLHtmlElement)
-            ) {
-                var doc = (typeof HTMLTemplateElement === 'function') ?
-                    document.createElement('template').content.ownerDocument :
-                    document;
-                var freshdom = doc.implementation.createHTMLDocument('');
-                body = WHOLE_DOCUMENT
-                    ? freshdom.getElementsByTagName.call(dom,'html')[0]
-                    : freshdom.getElementsByTagName.call(dom,'body')[0];
-            }
-            return body;
-        };
-
-        /**
-         * _createIterator
-         *
-         * @param  document/fragment to create iterator for
-         * @return iterator instance
-         */
-        var _createIterator = function(doc) {
-            return document.createNodeIterator(
-                doc,
-                NodeFilter.SHOW_ELEMENT
-                | NodeFilter.SHOW_COMMENT
-                | NodeFilter.SHOW_TEXT,
-                function() { return NodeFilter.FILTER_ACCEPT; },
-                false
-            );
-        };
-
-        /**
-         * _isClobbered
-         *
-         * @param  element to check for clobbering attacks
-         * @return true if clobbered, false if safe
-         */
-        var _isClobbered = function(elm) {
-            if (elm instanceof Text) {
-                return false;
-            }
-            if (
-                (elm.children && !(elm.children instanceof HTMLCollection))
-                || (elm.attributes instanceof HTMLCollection)
-                || (elm.attributes instanceof NodeList)
-                || (elm.insertAdjacentHTML && typeof elm.insertAdjacentHTML !== 'function')
-                || (elm.outerHTML && typeof elm.outerHTML !== 'string')
-                || typeof elm.nodeName !== 'string'
-                || typeof elm.textContent !== 'string'
-                || typeof elm.nodeType !== 'number'
-                || typeof elm.COMMENT_NODE !== 'number'
-                || typeof elm.setAttribute !== 'function'
-                || typeof elm.hasAttribute !== 'function'
-                || typeof elm.cloneNode !== 'function'
-                || typeof elm.removeAttributeNode !== 'function'
-                || typeof elm.removeChild !== 'function'
-                || typeof elm.attributes.item !== 'function'
-                || (elm.id === 'createElement' || elm.name === 'createElement')
-                || (elm.id === 'implementation' || elm.name === 'implementation')
-                || (elm.id === 'createNodeIterator' || elm.name === 'createNodeIterator')
-            ) {
-                return true;
-            }
-            return false;
-        };
-
-        /**
-         * _sanitizeElements
-         *
-         * @protect removeChild
-         * @protect nodeType
-         * @protect nodeName
-         * @protect textContent
-         * @protect outerHTML
-         * @protect currentNode
-         * @protect insertAdjacentHTML
-         *
-         * @param   node to check for permission to exist
-         * @return  true if node was killed, false if left alive
-         */
-        var _sanitizeElements = function(currentNode) {
-            /* Execute a hook if present */
-            _executeHook('beforeSanitizeElements', currentNode, null);
-
-            /* Check if element is clobbered or can clobber */
-            if (_isClobbered(currentNode)) {
-                /* Be harsh with clobbered content, element has to go! */
-                try {
-                    currentNode.parentNode.removeChild(currentNode);
-                } catch (e) {
-                    currentNode.outerHTML = '';
-                }
-                return true;
-            }
-
-            /* Now let's check the element's type and name */
-            var tagName = currentNode.nodeName.toLowerCase();
-
-            /* Execute a hook if present */
-            _executeHook('uponSanitizeElement', currentNode, {
-                tagName: tagName
-            });
-
-            /* Remove element if anything forbids its presence */
-            if (!ALLOWED_TAGS[tagName] || FORBID_TAGS[tagName]) {
-                /* Keep content for white-listed elements */
-                if (KEEP_CONTENT && currentNode.insertAdjacentHTML
-                    && CONTENT_TAGS[tagName]){
-                    try {
-                        currentNode.insertAdjacentHTML('AfterEnd', currentNode.innerHTML);
-                    } catch (e) {}
-                }
-                currentNode.parentNode.removeChild(currentNode);
-                return true;
-            }
-
-            /* Finally, convert markup to cover jQuery behavior */
-            if (SAFE_FOR_JQUERY && !currentNode.firstElementChild) {
-                currentNode.innerHTML = currentNode.textContent.replace(/</g, '&lt;');
-            }
-
-            /* Execute a hook if present */
-            _executeHook('afterSanitizeElements', currentNode, null);
-
-            return false;
-        };
-
-        /**
-         * _sanitizeAttributes
-         *
-         * @protect attributes
-         * @protect removeAttributeNode
-         * @protect setAttribute
-         * @protect cloneNode
-         *
-         * @param   node to sanitize
-         * @return  void
-         */
-        var _sanitizeAttributes = function(currentNode) {
-            /* Execute a hook if present */
-            _executeHook('beforeSanitizeAttributes', currentNode, null);
-
-            var isScriptOrData = /^(?:\w+script|data):/gi,
-                clonedNode = currentNode.cloneNode(false),
-                tmp, clobbering;
-
-            /* This needs to be extensive thanks to Webkit/Blink's behavior */
-            var whitespace = /[\x00-\x20\xA0\u1680\u180E\u2000-\u2029\u205f\u3000]/g;
-
-            /* Check if we have attributes; if not we might have a text node */
-            if (!currentNode.attributes) { return; }
-
-            /* Go backwards over all attributes; safely remove bad ones */
-            for (var attr = currentNode.attributes.length-1; attr >= 0; attr--) {
-                tmp = clonedNode.attributes[attr];
-                clobbering = false;
-                currentNode.removeAttribute(currentNode.attributes[attr].name);
-
-                if (!tmp instanceof Attr) { continue; }
-
-                if (SANITIZE_DOM) {
-                    if ((tmp.name === 'id' || tmp.name === 'name')
-                        && (tmp.value in window || tmp.value in document)) {
-                        clobbering = true;
-                    }
-                }
-                /* Safely handle attributes */
-                var attrName = tmp.name.toLowerCase();
-
-                /* Execute a hook if present */
-                _executeHook('uponSanitizeAttribute', currentNode, {
-                    attrName: attrName, attrValue: tmp.value, attr: tmp
-                });
-
-                if (
-                    ((ALLOWED_ATTR[attrName] && !FORBID_ATTR[attrName]) ||
-                     (ALLOW_DATA_ATTR && /^data-[\w-]+/i.test(tmp.name)))
-
-                    /* Get rid of script and data URIs */
-                    && (!isScriptOrData.test(tmp.value.replace(whitespace,''))
-
-                        /* Keep image data URIs alive if src is allowed */
-                        || (tmp.name === 'src'
-                            && tmp.value.indexOf('data:') === 0
-                            && currentNode.nodeName === 'IMG'))
-
-                    /* Make sure attribute cannot clobber */
-                    && !clobbering
-                ) {
-                    /* Handle invalid data attribute set by try-catching it */
-                    try {
-                        currentNode.setAttribute(tmp.name, tmp.value);
-                    } catch (e) {}
-                }
-            }
-
-            /* Execute a hook if present */
-            _executeHook('afterSanitizeAttributes', currentNode, null);
-        };
-
-        /**
-         * _sanitizeShadowDOM
-         *
-         * @param  fragment to iterate over recursively
-         * @return void
-         */
-        var _sanitizeShadowDOM = function(fragment) {
-            var shadowNode;
-            var shadowIterator = _createIterator(fragment);
-
-            /* Execute a hook if present */
-            _executeHook('beforeSanitizeShadowDOM', fragment, null);
-
-            while (shadowNode = shadowIterator.nextNode()) {
-                /* Execute a hook if present */
-                _executeHook('uponSanitizeShadowNode', shadowNode, null);
-
-                /* Sanitize tags and elements */
-                if (_sanitizeElements(shadowNode)) {
-                    continue;
-                }
-
-                /* Deep shadow DOM detected */
-                if (shadowNode.content instanceof DocumentFragment) {
-                    _sanitizeShadowDOM(shadowNode.content);
-                }
-
-                /* Check attributes, sanitize if necessary */
-                _sanitizeAttributes(shadowNode);
-            }
-
-            /* Execute a hook if present */
-            _executeHook('afterSanitizeShadowDOM', fragment, null);
-        };
-
-        /**
-         * _executeHook
-         * Execute user configurable hooks
-         *
-         * @param  {String} entryPoint  Name of the hook's entry point
-         * @param  {Node} currentNode
-         */
-        var _executeHook = function(entryPoint, currentNode, data) {
-            if (!hooks[entryPoint]) { return; }
-
-            hooks[entryPoint].forEach(function(hook) {
-                hook.call(DOMPurify, currentNode, data, cfg);
-            });
-        };
-
         /* Check we can run. Otherwise fall back or ignore */
         if (!DOMPurify.isSupported) {
             if (typeof window.toStaticHTML === 'function' && typeof dirty === 'string') {
@@ -488,7 +516,7 @@
         }
 
         /* Assign config vars */
-        cfg ? _parseConfig(cfg) : null;
+        _parseConfig(cfg);
 
         /* Exit directly if we have nothing to do */
         if (!RETURN_DOM && !WHOLE_DOCUMENT && dirty.indexOf('<') === -1) {

--- a/purify.js
+++ b/purify.js
@@ -364,7 +364,7 @@
             _executeHook('beforeSanitizeAttributes', currentNode, null);
 
             var regex = /^(\w+script|data):/gi,
-                clonedNode = currentNode.cloneNode(true),
+                clonedNode = currentNode.cloneNode(false),
                 tmp, clobbering;
 
             /* This needs to be extensive thanks to Webkit/Blink's behavior */

--- a/purify.js
+++ b/purify.js
@@ -363,7 +363,7 @@
             /* Execute a hook if present */
             _executeHook('beforeSanitizeAttributes', currentNode, null);
 
-            var regex = /^(\w+script|data):/gi,
+            var isScriptOrData = /^(?:\w+script|data):/gi,
                 clonedNode = currentNode.cloneNode(false),
                 tmp, clobbering;
 
@@ -398,10 +398,10 @@
                 if (
                     ((ALLOWED_ATTR.indexOf(attrName) > -1 &&
                       FORBID_ATTR.indexOf(attrName) === -1) ||
-                    (ALLOW_DATA_ATTR && tmp.name.match(/^data-[\w-]+/i)))
+                    (ALLOW_DATA_ATTR && /^data-[\w-]+/i.test(tmp.name)))
 
                     /* Get rid of script and data URIs */
-                    && (!tmp.value.replace(whitespace,'').match(regex)
+                    && (!isScriptOrData.test(tmp.value.replace(whitespace,''))
 
                         /* Keep image data URIs alive if src is allowed */
                         || (tmp.name === 'src'

--- a/test/index.html
+++ b/test/index.html
@@ -24,11 +24,11 @@
 
     // Don't start tests automatically
     QUnit.config.autostart = false;
-    
+
     QUnit.assert.contains = function( needle, haystack, message ) {
         var actual = haystack.indexOf(needle) > -1;
         QUnit.push(actual, actual, needle, message);
-    };    
+    };
 
     // Load assertions
     jQuery
@@ -40,44 +40,44 @@
         var xssTests = tests.filter( function( element ) {
           if ( /alert/.test( element.payload ) ) { return element; }
         });
-        
+
         // Sanitization tests
         QUnit
           .cases(tests)
           .test( 'Sanitization test', function(params, assert) {
               assert.contains( DOMPurify.sanitize( params.payload ), params.expected );
           });
-        
+
         // Config-Flag Tests
         QUnit.test( 'Config-Flag tests: KEEP_CONTENT + ALLOWED_TAGS / ALLOWED_ATTR', function(assert) {
             // KEEP_CONTENT + ALLOWED_TAGS / ALLOWED_ATTR
             assert.equal( DOMPurify.sanitize( '<iframe>Hello</iframe>', {KEEP_CONTENT: false} ), "");
-            assert.contains( DOMPurify.sanitize( '<a href="#">abc<b style="color:red">123</b><q class="cite">123</b></a>', {ALLOWED_TAGS: ['b', 'q'], ALLOWED_ATTR: ['style'], KEEP_CONTENT: true}), 
+            assert.contains( DOMPurify.sanitize( '<a href="#">abc<b style="color:red">123</b><q class="cite">123</b></a>', {ALLOWED_TAGS: ['b', 'q'], ALLOWED_ATTR: ['style'], KEEP_CONTENT: true}),
                 ["abc<b style=\"color:red\">123</b><q>123</q>", "abc<b style=\"color: red;\">123</b><q>123</q>"]
             );
             assert.equal( DOMPurify.sanitize( '<a href="#">abc<b style="color:red">123</b><q class="cite">123</b></a>', {ALLOWED_TAGS: ['b', 'q'], ALLOWED_ATTR: ['style'], KEEP_CONTENT: false}), "");
             assert.equal( DOMPurify.sanitize( '<a href="#">abc</a>', {ALLOWED_TAGS: ['b', 'q'], KEEP_CONTENT: false}), "");
         });
-        
+
         QUnit.test( 'Config-Flag tests: ALLOW_DATA_ATTR', function(assert) {
             // ALLOW_DATA_ATTR
             assert.equal( DOMPurify.sanitize( '<a href="#" data-abc\"="foo">abc</a>', {ALLOW_DATA_ATTR: true}), "<a href=\"#\">abc</a>" );
             assert.equal( DOMPurify.sanitize( '<a href="#" data-abc="foo">abc</a>', {ALLOW_DATA_ATTR: false}), "<a href=\"#\">abc</a>" );
-            assert.contains( DOMPurify.sanitize( '<a href="#" data-abc="foo">abc</a>', {ALLOW_DATA_ATTR: true}), 
-                ["<a data-abc=\"foo\" href=\"#\">abc</a>", "<a href=\"#\" data-abc=\"foo\">abc</a>"] 
+            assert.contains( DOMPurify.sanitize( '<a href="#" data-abc="foo">abc</a>', {ALLOW_DATA_ATTR: true}),
+                ["<a data-abc=\"foo\" href=\"#\">abc</a>", "<a href=\"#\" data-abc=\"foo\">abc</a>"]
             );
-            assert.contains( DOMPurify.sanitize( '<a href="#" data-abc-1-2-3="foo">abc</a>', {ALLOW_DATA_ATTR: true}), 
-                ["<a data-abc-1-2-3=\"foo\" href=\"#\">abc</a>", "<a href=\"#\" data-abc-1-2-3=\"foo\">abc</a>"]  
+            assert.contains( DOMPurify.sanitize( '<a href="#" data-abc-1-2-3="foo">abc</a>', {ALLOW_DATA_ATTR: true}),
+                ["<a data-abc-1-2-3=\"foo\" href=\"#\">abc</a>", "<a href=\"#\" data-abc-1-2-3=\"foo\">abc</a>"]
             );
             assert.equal( DOMPurify.sanitize( '<a href="#" data-""="foo">abc</a>', {ALLOW_DATA_ATTR: true}), "<a href=\"#\">abc</a>" );
-        });         
-        
+        });
+
         QUnit.test( 'Config-Flag tests: ADD_TAGS', function(assert) {
             // ADD_TAGS
             assert.equal( DOMPurify.sanitize( '<my-component>abc</my-component>', {ADD_TAGS: ['my-component']}), "<my-component>abc</my-component>" );
             assert.equal( DOMPurify.sanitize( '<my-ĸompønent>abc</my-ĸompønent>', {ADD_TAGS: ['my-ĸompønent']}), "<my-ĸompønent>abc</my-ĸompønent>" );
         });
-        
+
         QUnit.test( 'Config-Flag tests: ADD_TAGS + ADD_ATTR', function(assert) {
             // ADD_TAGS + ADD_ATTR
             assert.equal( DOMPurify.sanitize( '<my-component my-attr="foo">abc</my-component>', {ADD_TAGS: ['my-component']}), "<my-component>abc</my-component>" );
@@ -85,7 +85,7 @@
             assert.equal( DOMPurify.sanitize( '<my-ĸompønent my-æŧŧr="foo">abc</my-ĸompønent>', {ADD_TAGS: ['my-ĸompønent']}), "<my-ĸompønent>abc</my-ĸompønent>" );
             assert.equal( DOMPurify.sanitize( '<my-ĸompønent my-æŧŧr="foo">abc</my-ĸompønent>', {ADD_TAGS: ['my-ĸompønent'], ADD_ATTR: ['my-æŧŧr']}), "<my-ĸompønent my-æŧŧr=\"foo\">abc</my-ĸompønent>" );
         });
-        
+
         QUnit.test( 'Config-Flag tests: SAFE_FOR_JQUERY', function(assert) {
             //SAFE_FOR_JQUERY
             assert.equal( DOMPurify.sanitize( '<a>123</a><option><style><img src=x onerror=alert(1)>', {SAFE_FOR_JQUERY: false}), "<a>123</a><option><style><img src=x onerror=alert(1)></style></option>" );
@@ -97,7 +97,7 @@
             assert.equal( DOMPurify.sanitize( '<b><style><style/><img src=xx: onerror=alert(1)>', {SAFE_FOR_JQUERY: false}), "<b><style><style/><img src=xx: onerror=alert(1)></style></b>" );
             assert.equal( DOMPurify.sanitize( '<b><style><style/><img src=xx: onerror=alert(1)>', {SAFE_FOR_JQUERY: true}), "<b><style>&lt;style/>&lt;img src=xx: onerror=alert(1)></style></b>" );
         });
-        
+
         QUnit.test( 'Config-Flag tests: SANITIZE_DOM', function(assert) {
             // SANITIZE_DOM
             assert.equal( DOMPurify.sanitize( '<form name="window">', {SANITIZE_DOM: true}), "<form></form>" );
@@ -106,14 +106,14 @@
             assert.equal( DOMPurify.sanitize( '<img src="x" name="getElementById">', {SANITIZE_DOM: false}), "<img name=\"getElementById\" src=\"x\">" );
             assert.equal( DOMPurify.sanitize( '<img src="x" name="getElementById">', {SANITIZE_DOM: true}), "<img src=\"x\">" );
             assert.equal( DOMPurify.sanitize( '<a href="x" id="location">click</a>', {SANITIZE_DOM: true}), "<a href=\"x\">click</a>" );
-            assert.contains( DOMPurify.sanitize( '<form><input name="attributes"></form>', {ADD_TAGS: ['form'], SANITIZE_DOM: false}), 
-                ["", "<form><input name=\"attributes\"></form>"] 
+            assert.contains( DOMPurify.sanitize( '<form><input name="attributes"></form>', {ADD_TAGS: ['form'], SANITIZE_DOM: false}),
+                ["", "<form><input name=\"attributes\"></form>"]
             );
-            assert.contains( DOMPurify.sanitize( '<form><input name="attributes"></form>', {ADD_TAGS: ['form'], SANITIZE_DOM: true}), 
-                ["", "<form><input name=\"attributes\"></form>", "<form><input></form>"] 
-            ); 
+            assert.contains( DOMPurify.sanitize( '<form><input name="attributes"></form>', {ADD_TAGS: ['form'], SANITIZE_DOM: true}),
+                ["", "<form><input name=\"attributes\"></form>", "<form><input></form>"]
+            );
         });
-        
+
         QUnit.test( 'Config-Flag tests: WHOLE_DOCUMENT', function(assert) {
             //WHOLE_DOCUMENT
             assert.equal( DOMPurify.sanitize( '123', {WHOLE_DOCUMENT: false}), "123" );
@@ -123,15 +123,16 @@
             assert.equal( DOMPurify.sanitize( '123<style>*{color:red}</style>', {WHOLE_DOCUMENT: false}), "123<style>*{color:red}</style>" );
             assert.equal( DOMPurify.sanitize( '123<style>*{color:red}</style>', {WHOLE_DOCUMENT: true}), "<html><head></head><body>123<style>*{color:red}</style></body></html>" );
         });
-        
+
         QUnit.test( 'Config-Flag tests: RETURN_DOM', function(assert) {
             //RETURN_DOM
             assert.equal( DOMPurify.sanitize( '<a>123<b>456</b></a>', {RETURN_DOM: true}).outerHTML, "<body><a>123<b>456</b></a></body>" );
             assert.equal( DOMPurify.sanitize( '<a>123<b>456<script>alert(1)<\/script></b></a>', {RETURN_DOM: true}).outerHTML, "<body><a>123<b>456</b></a></body>" );
             assert.equal( DOMPurify.sanitize( '<a>123<b>456</b></a>', {RETURN_DOM: true, WHOLE_DOCUMENT: true}).outerHTML, "<html><head></head><body><a>123<b>456</b></a></body></html>" );
             assert.equal( DOMPurify.sanitize( '<a>123<b>456<script>alert(1)<\/script></b></a>', {RETURN_DOM: true, WHOLE_DOCUMENT: true}).outerHTML, "<html><head></head><body><a>123<b>456</b></a></body></html>" );
+            assert.equal( DOMPurify.sanitize( '123', {RETURN_DOM: true}).outerHTML, "<body>123</body>" );
         });
-        
+
         QUnit.test( 'Config-Flag tests: FORBID_TAGS', function(assert) {
             //FORBID_TAGS
             assert.equal( DOMPurify.sanitize( '<a>123<b>456</b></a>', {FORBID_TAGS: ['b']}), "<a>123456</a>" );
@@ -139,7 +140,7 @@
             assert.equal( DOMPurify.sanitize( '<a>123<b>456</b></a>', {FORBID_TAGS: ['c']}), "<a>123<b>456</b></a>" );
             assert.equal( DOMPurify.sanitize( '<a>123<b>456<script>alert(1)<\/script></b></a>789', {FORBID_TAGS: ['script', 'b']}), "<a>123456</a>789" );
             assert.equal( DOMPurify.sanitize( '<a>123<b>456</b></a>', {ADD_TAGS: ['b'], FORBID_TAGS: ['b']}), "<a>123456</a>" );
-        });        
+        });
 
         QUnit.test( 'Config-Flag tests: FORBID_ATTR', function(assert) {
             //FORBID_ATTR
@@ -147,8 +148,8 @@
             assert.equal( DOMPurify.sanitize( '<a class="0" x="1">123<b y="1">456<script>alert(1)<\/script></b></a>789', {FORBID_ATTR: ['x', 'y']}), "<a class=\"0\">123<b>456</b></a>789" );
             assert.equal( DOMPurify.sanitize( '<a y="1">123<b y="1" y="2">456</b></a>', {FORBID_ATTR: ['y']}), "<a>123<b>456</b></a>" );
             assert.equal( DOMPurify.sanitize( '<a>123<b x="1">456<script y="1">alert(1)<\/script></b></a>789', {FORBID_ATTR: ['x', 'y']}), "<a>123<b>456</b></a>789" );
-        }); 
-                
+        });
+
         // XSS tests: Native DOM methods (alert() should not be called)
         QUnit
           .cases(xssTests)
@@ -164,7 +165,7 @@
                 window.xssed = false;
               }, 100);
           });
-        
+
 
         // XSS tests: jQuery (alert() should not be called)
         QUnit

--- a/test/index.html
+++ b/test/index.html
@@ -117,7 +117,7 @@
         QUnit.test( 'Config-Flag tests: WHOLE_DOCUMENT', function(assert) {
             //WHOLE_DOCUMENT
             assert.equal( DOMPurify.sanitize( '123', {WHOLE_DOCUMENT: false}), "123" );
-            assert.equal( DOMPurify.sanitize( '123', {WHOLE_DOCUMENT: true}), "123" );
+            assert.equal( DOMPurify.sanitize( '123', {WHOLE_DOCUMENT: true}), "<html><head></head><body>123</body></html>" );
             assert.equal( DOMPurify.sanitize( '<style>*{color:red}</style>', {WHOLE_DOCUMENT: false}), "" );
             assert.equal( DOMPurify.sanitize( '<style>*{color:red}</style>', {WHOLE_DOCUMENT: true}), "<html><head><style>*{color:red}</style></head><body></body></html>" );
             assert.equal( DOMPurify.sanitize( '123<style>*{color:red}</style>', {WHOLE_DOCUMENT: false}), "123<style>*{color:red}</style>" );

--- a/test/index.html
+++ b/test/index.html
@@ -183,6 +183,11 @@
               }, 100);
           });
 
+        // Check for isSupported property
+        QUnit.test( 'DOMPurify property tests', function(assert) {
+            assert.equal( typeof DOMPurify.isSupported, 'boolean' );
+        });
+
         // Fire it up!
         QUnit.start();
       });


### PR DESCRIPTION
This pull request encompasses the following refinements:
1. Optimise: without changing the semantics, many easy optimisations were made, for example changing from searching an array for allowed tags/attributes [O(n)] to constructing a lookup table [O(1)].
2. Fix small documentation errors, typos and whitespace inconsistencies.
3. Add an "isSupported" property to the DOMPurify object to allow users to easily check if the browser supports the full DOMPurify.
4. Fix a bug where sanitize would return a string even when RETURN_DOM is set, if the input had no "<" character.
5. Always return the full html including browser inferred `<html><body>` etc. tags if WHOLE_DOCUMENT config option is set, even if the input has no "<" character.

The test suite has one modification for (5). No other semantic changes were made and the full test suite runs without error in latest Chrome.