### PR TITLE
Tidy, optimise & improve hook in _sanitizeAttributes

### DIFF
--- a/demos/hooks-mentaljs-demo.html
+++ b/demos/hooks-mentaljs-demo.html
@@ -60,11 +60,11 @@
                 if(data.attrName.match(/^on\w+/)) {
                     var script = data.attrValue;
                     try {
-                        return data.attr.value = MentalJS().parse(
+                        return data.attrValue = MentalJS().parse(
                             {options:{eval:false, dom:true}, code:script}
                         );
                     } catch(e) {
-                        return data.attr.value = '';
+                        return data.attrValue = '';
                     }
                 }
             });            


### PR DESCRIPTION
* Tidies code, reordering a few things for more efficient execution, removing
  the need to clone the DOM node and caching values in local variables to
  reduce object lookup costs.
* Improves the uponSanitizeAttribute hook:
  - The hook is now called *before* removing the attribute from the node. This
    allows the hook to access any parsed version of the attribute available on
    the node (e.g. the "style" attribute).
* The hook no longer passes the attr object itself, since this contains no
  extra information beyond the name/value already in the hook data.
* The hook has a new "keepAttr" property, which may be set to `false` by the
  hook to reject the attribute even if it would otherwise be kept by the
  whitelist.
* The hook function may change the value to be set for the attribute by setting
  the attrValue property on the hook data object it is passed.

All tests pass in latest Chrome & Firefox.