### PR TITLE
Workaround Safari Crash

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -593,7 +593,9 @@
      * @return void
      */
     DOMPurify.removeHook = function(entryPoint) {
-        if (hooks[entryPoint]) {hooks[entryPoint].pop()}
+        if (hooks[entryPoint]) {
+            hooks[entryPoint].pop();
+        }
     };
 
     /**
@@ -604,7 +606,9 @@
      * @return void
      */
     DOMPurify.removeHooks = function(entryPoint) {
-        if (hooks[entryPoint]) {hooks[entryPoint] = []}
+        if (hooks[entryPoint]) {
+            hooks[entryPoint] = [];
+        }
     };
 
     /**

--- a/purify.js
+++ b/purify.js
@@ -406,7 +406,7 @@
                 keepAttr: true
             },
             l = attributes.length,
-            attr, name, value, lcName;
+            attr, name, value, lcName, idAttr;
 
         /* Go backwards over all attributes; safely remove bad ones */
         while (l--) {
@@ -423,10 +423,24 @@
             value = hookEvent.attrValue;
 
             /* Remove attribute */
-            currentNode.removeAttribute(name);
+            // Safari (iOS + Mac), last tested v8.0.5, crashes if you try to
+            // remove a "name" attribute from an <img> tag that has an "id"
+            // attribute at the time.
+            if (lcName === 'name'  &&
+                    currentNode.nodeName === 'IMG' && currentNode.id) {
+                idAttr = attributes.id;
+                attributes = Array.prototype.slice.apply(attributes);
+                currentNode.removeAttribute('id');
+                currentNode.removeAttribute(name);
+                if (attributes.indexOf(idAttr) > l) {
+                    currentNode.setAttribute('id', idAttr.value);
+                }
+            } else {
+                currentNode.removeAttribute(name);
+            }
 
             /* Did the hooks approve of the attribute? */
-            if ( !hookEvent.keepAttr ) {
+            if (!hookEvent.keepAttr) {
                 continue;
             }
 

--- a/test/expect.json
+++ b/test/expect.json
@@ -279,7 +279,10 @@
     },
     {
         "payload": "<div id=\"1\"><form id=\"test\"></form><button form=\"test\" formaction=\"javascript:alert(1)\">X</button>//[\"'`-->]]>]</div>",
-        "expected": "<div id=\"1\"><form></form><button>X</button>//[\"'`--&gt;]]&gt;]</div>"
+        "expected": [
+            "<div id=\"1\"><form></form><button>X</button>//[\"'`--&gt;]]&gt;]</div>",
+            "<div id=\"1\"><form><button>X</button>//[\"'`--&gt;]]&gt;]</form></div>"
+        ]
     },
     {
         "payload": "<div id=\"2\"><meta charset=\"x-imap4-modified-utf7\">&ADz&AGn&AG0&AEf&ACA&AHM&AHI&AGO&AD0&AGn&ACA&AG8Abg&AGUAcgByAG8AcgA9AGEAbABlAHIAdAAoADEAKQ&ACAAPABi//[\"'`-->]]>]</div>",
@@ -372,7 +375,10 @@
     },
     {
         "payload": "<div id=\"23\"><form id=test onforminput=alert(23)><input></form><button form=test onformchange=alert(2)>X</button>//[\"'`-->]]>]</div>",
-        "expected": "<div id=\"23\"><form><input></form><button>X</button>//[\"'`--&gt;]]&gt;]</div>"
+        "expected": [
+            "<div id=\"23\"><form><input></form><button>X</button>//[\"'`--&gt;]]&gt;]</div>",
+            "<div id=\"23\"><form><input><button>X</button>//[\"'`--&gt;]]&gt;]</form></div>"
+        ]
     },
     {
         "payload": "<div id=\"24\">1<set/xmlns=`urn:schemas-microsoft-com:time` style=`behAvior:url(#default#time2)` attributename=`innerhtml` to=`<img/src=\"x\"onerror=alert(24)>`>//[\"'`-->]]>]</div>",
@@ -942,6 +948,7 @@
         "payload": "<div id=\"132\"><!doctype html>\n<form>\n<label>type a,b,c,d - watch the network tab/traffic (JS is off, latest NoScript)</label>\n<br>\n<input name=\"secret\" type=\"password\">\n</form>\n<!-- injection --><svg height=\"50px\">\n<image xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<set attributeName=\"xlink:href\" begin=\"accessKey(a)\" to=\"//example.com/?a\" />\n<set attributeName=\"xlink:href\" begin=\"accessKey(b)\" to=\"//example.com/?b\" />\n<set attributeName=\"xlink:href\" begin=\"accessKey(c)\" to=\"//example.com/?c\" />\n<set attributeName=\"xlink:href\" begin=\"accessKey(d)\" to=\"//example.com/?d\" />\n</image>\n</svg>//[\"'`-->]]>]</div>",
         "expected": [
                         "<div id=\"132\">\n<form>\n<label>type a,b,c,d - watch the network tab/traffic (JS is off, latest NoScript)</label>\n<br>\n<input type=\"password\" name=\"secret\">\n</form>\n<svg height=\"50px\">\n<image>\n\n\n\n\n</image>\n</svg>//[\"'`--&gt;]]&gt;]</div>",
+                        "<div id=\"132\">\n<form>\n<label>type a,b,c,d - watch the network tab/traffic (JS is off, latest NoScript)</label>\n<br>\n<input type=\"password\" name=\"secret\">\n\n<svg height=\"50px\">\n<image>\n\n\n\n\n</image>\n</svg>//[\"'`--&gt;]]&gt;]</form></div>",
                         "<div id=\"132\">\n<form>\n<label>type a,b,c,d - watch the network tab/traffic (JS is off, latest NoScript)</label>\n<br>\n<input name=\"secret\" type=\"password\">\n</form>\n<svg height=\"50px\">\n<image>\n\n\n\n\n</image>\n</svg>//[\"'`--&gt;]]&gt;]</div>",
                         "<div id=\"132\">\n<form>\n<label>type a,b,c,d - watch the network tab/traffic (JS is off, latest NoScript)</label>\n<br>\n<input name=\"secret\" type=\"password\">\n</form>\n<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"50px\">\n<image>\n\n\n\n\n</image>\n</svg>//[\"'`--&gt;]]&gt;]</div>"
                     ]
@@ -967,6 +974,7 @@
         "payload": "<div id=\"136\"><form action=\"\" method=\"post\">\n<input name=\"username\" value=\"admin\" />\n<input name=\"password\" type=\"password\" value=\"secret\" />\n<input name=\"injected\" value=\"injected\" dirname=\"password\" />\n<input type=\"submit\">\n</form>//[\"'`-->]]>]</div>",
         "expected": [
                         "<div id=\"136\"><form method=\"post\" action=\"\">\n<input value=\"admin\" name=\"username\">\n<input value=\"secret\" type=\"password\" name=\"password\">\n<input value=\"injected\" name=\"injected\">\n<input type=\"submit\">\n</form>//[\"'`--&gt;]]&gt;]</div>",
+                        "<div id=\"136\"><form method=\"post\" action=\"\">\n<input value=\"admin\" name=\"username\">\n<input value=\"secret\" type=\"password\" name=\"password\">\n<input value=\"injected\" name=\"injected\">\n<input type=\"submit\">\n//[\"'`--&gt;]]&gt;]</form></div>",
                         "<div id=\"136\"><form method=\"post\" action=\"\">\n<input value=\"admin\" name=\"username\">\n<input value=\"secret\" name=\"password\" type=\"password\">\n<input value=\"injected\" name=\"injected\">\n<input type=\"submit\">\n</form>//[\"'`--&gt;]]&gt;]</div>",
                         "<div id=\"136\"><form action=\"\" method=\"post\">\n<input name=\"username\" value=\"admin\">\n<input name=\"password\" type=\"password\" value=\"secret\">\n<input name=\"injected\" value=\"injected\">\n<input type=\"submit\" value=\"Submit Query\">\n</form>//[\"'`--&gt;]]&gt;]</div>"
                     ]

--- a/test/expect.json
+++ b/test/expect.json
@@ -3,43 +3,43 @@
     {
         "title": "DOM Clobbering against document.createElement() (see #47)",
         "payload": "<img src=x name=createElement><img src=y id=createElement>",
-        "expected": "<img src=\"x\"><img src=\"y\">"        
-    },    
+        "expected": "<img src=\"x\"><img src=\"y\">"
+    },
     {
         "title": "DOM Clobbering against an empty cookie",
         "payload": "<img src=x name=cookie>",
-        "expected": "<img src=\"x\">"        
+        "expected": "<img src=\"x\">"
     },
     {
         "title": "JavaScript URIs using Unicode LS/PS I",
         "payload": "123<a href='\u2028javascript:alert(1)'>I am a dolphin!</a>",
-        "expected": "123<a>I am a dolphin!</a>"        
+        "expected": "123<a>I am a dolphin!</a>"
     },
     {
         "title": "JavaScript URIs using Unicode LS/PS II",
         "payload": "123<a href='\u2028javascript:alert(1)'>I am a dolphin too!</a>",
-        "expected": "123<a>I am a dolphin too!</a>"        
-    },    
+        "expected": "123<a>I am a dolphin too!</a>"
+    },
     {
         "title": "JavaScript URIs using Unicode Whitespace",
-        "payload": "123<a href=' javascript:alert(1)'>CLICK</a><a href='&#xA0javascript:alert(1)'>CLICK</a><a href='&#x1680;javascript:alert(1)'>CLICK</a><a href='&#x180E;javascript:alert(1)'>CLICK</a><a href='&#x2000;javascript:alert(1)'>CLICK</a><a href='&#x2001;javascript:alert(1)'>CLICK</a><a href='&#x2002;javascript:alert(1)'>CLICK</a><a href='&#x2003;javascript:alert(1)'>CLICK</a><a href='&#x2004;javascript:alert(1)'>CLICK</a><a href='&#x2005;javascript:alert(1)'>CLICK</a><a href='&#x2006;javascript:alert(1)'>CLICK</a><a href='&#x2006;javascript:alert(1)'>CLICK</a><a href='&#x2007;javascript:alert(1)'>CLICK</a><a href='&#x2008;javascript:alert(1)'>CLICK</a><a href='&#x2009;javascript:alert(1)'>CLICK</a><a href='&#x200A;javascript:alert(1)'>CLICK</a><a href='&#x200B;javascript:alert(1)'>CLICK</a><a href='&#x205f;javascript:alert(1)'>CLICK</a><a href='&#x3000;javascript:alert(1)'>CLICK</a>",        
-        "expected": "123<a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a>"        
-    },      
+        "payload": "123<a href=' javascript:alert(1)'>CLICK</a><a href='&#xA0javascript:alert(1)'>CLICK</a><a href='&#x1680;javascript:alert(1)'>CLICK</a><a href='&#x180E;javascript:alert(1)'>CLICK</a><a href='&#x2000;javascript:alert(1)'>CLICK</a><a href='&#x2001;javascript:alert(1)'>CLICK</a><a href='&#x2002;javascript:alert(1)'>CLICK</a><a href='&#x2003;javascript:alert(1)'>CLICK</a><a href='&#x2004;javascript:alert(1)'>CLICK</a><a href='&#x2005;javascript:alert(1)'>CLICK</a><a href='&#x2006;javascript:alert(1)'>CLICK</a><a href='&#x2006;javascript:alert(1)'>CLICK</a><a href='&#x2007;javascript:alert(1)'>CLICK</a><a href='&#x2008;javascript:alert(1)'>CLICK</a><a href='&#x2009;javascript:alert(1)'>CLICK</a><a href='&#x200A;javascript:alert(1)'>CLICK</a><a href='&#x200B;javascript:alert(1)'>CLICK</a><a href='&#x205f;javascript:alert(1)'>CLICK</a><a href='&#x3000;javascript:alert(1)'>CLICK</a>",
+        "expected": "123<a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a><a>CLICK</a>"
+    },
     {
         "title": "Image with data URI src",
         "payload": "<img src=data:image/jpeg,ab798ewqxbaudbuoibeqbla>",
-        "expected": "<img src=\"data:image/jpeg,ab798ewqxbaudbuoibeqbla\">"        
+        "expected": "<img src=\"data:image/jpeg,ab798ewqxbaudbuoibeqbla\">"
     },
     {
         "title": "Image with JavaScript URI src (DoS on Firefox)",
         "payload": "<img src='javascript:while(1){}'>",
-        "expected": "<img>"        
-    },    
+        "expected": "<img>"
+    },
     {
         "title": "Link with data URI href",
         "payload": "<a href=data:,evilnastystuff>clickme</a>",
-        "expected": "<a>clickme</a>"        
-    },    
+        "expected": "<a>clickme</a>"
+    },
     {
         "title": "Simple numbers",
         "payload": "123456",
@@ -986,5 +986,10 @@
                         "<div id=\"137\"><svg>\n<a xlink:href=\"?\">\n<circle r=\"400\"></circle>\n\n</a>//[\"'`--&gt;]]&gt;]</svg></div>",
                         "<div id=\"137\"><svg xmlns=\"http://www.w3.org/2000/svg\">\n<a xmlns:NS1=\"\" NS1:xlink:href=\"?\">\n<circle r=\"400\" />\n\n</a>//[\"'`--&gt;]]&gt;]</svg></svg></div>"
                     ]
+    },
+    {
+        "title": "Removing name attr from img with id can crash Safari",
+        "payload": "<img name=\"bar\" id=\"foo\">",
+        "expected": "<img id=\"foo\" name=\"bar\">"
     }
 ]

--- a/test/index.html
+++ b/test/index.html
@@ -27,7 +27,7 @@
 
     QUnit.assert.contains = function( needle, haystack, message ) {
         var actual = haystack.indexOf(needle) > -1;
-        QUnit.push(actual, actual, needle, message);
+        QUnit.push(actual, needle, haystack, message);
     };
 
     // Load assertions


### PR DESCRIPTION
Safari (latest version on both iOS + Mac) will crash hard if you try to remove a "name" attribute from an image node that also has an "id" attribute. I've filed a bug with Apple, but in the meantime this patch works around the issue.

Also, I've fixed up the tests so they all pass in Safari: it has slightly different behaviour parsing form tags.