### PR TITLE
Allow more benign contents/attributes

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -96,16 +96,17 @@
     var DEFAULT_ALLOWED_ATTR = _addToSet({}, [
 
         // HTML
-        'accept','action','align','alt','autocomplete','bgcolor','border',
-        'checked','cite','class','color','cols','colspan','coords','datetime',
-        'default','dir','disabled','download','enctype','for','headers','height',
-        'hidden','high','href','hreflang','id','ismap','label','lang','list',
-        'loop', 'low','max','maxlength','media','method','min','multiple',
-        'name','novalidate','open','optimum','pattern','placeholder','poster',
-        'preload','pubdate','radiogroup','readonly','rel','required','rev',
-        'reversed','rows','rowspan','spellcheck','scope','selected','shape',
-        'size','span','srclang','start','src','step','style','summary','tabindex',
-        'title','type','usemap','valign','value','width','xmlns',
+        'accept','action','align','alt','autocomplete','background','bgcolor',
+        'border','cellpadding','cellspacing','checked','cite','class','color',
+        'cols','colspan','coords','datetime','default','dir','disabled',
+        'download','enctype','for','headers','height','hidden','high','href',
+        'hreflang','id','ismap','label','lang','list','loop', 'low','max',
+        'maxlength','media','method','min','multiple','name','novalidate',
+        'open','optimum','pattern','placeholder','poster','preload','pubdate',
+        'radiogroup','readonly','rel','required','rev','reversed','rows',
+        'rowspan','spellcheck','scope','selected','shape','size','span',
+        'srclang','start','src','step','style','summary','tabindex','title',
+        'type','usemap','valign','value','width','xmlns',
 
         // SVG
         'accent-height','accumulate','additivive','alignment-baseline',

--- a/purify.js
+++ b/purify.js
@@ -171,7 +171,7 @@
         'big','blink','blockquote','caption','center','cite','code','col',
         'dd','del','details','dfn','dir','div','dl','dt','em','figcaption',
         'figure','footer','h1','h2','h3','h4','h5','h6','header','i','ins',
-        'kbd','label','legend','li','main','mark','marquee','nav','ol',
+        'kbd','label','legend','li','main','mark','marquee','nav','ol', 'o:p',
         'output','p','pre','q','rp','rt','ruby','s','samp','section','small',
         'span','strike','strong','sub','summary','sup','table','tbody','td',
         'tfoot','th','thead','time','tr','tt','u','ul','var'


### PR DESCRIPTION
This pull request makes the following changes:

1. Preserve contents of <o:p> tag
2. Allow background, cellpadding and cellspacing attributes

This is important for preserving the formatting of many HTML emails. It should not have any security implications.