### PR TITLE
Improve logging for assert.contains

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -26,8 +26,8 @@
     QUnit.config.autostart = false;
 
     QUnit.assert.contains = function( needle, haystack, message ) {
-        var actual = haystack.indexOf(needle) > -1;
-        QUnit.push(actual, needle, haystack, message);
+        var result = haystack.indexOf(needle) > -1;
+        QUnit.push(result, needle, haystack, message);
     };
 
     // Load assertions
@@ -45,7 +45,7 @@
         QUnit
           .cases(tests)
           .test( 'Sanitization test', function(params, assert) {
-              assert.contains( DOMPurify.sanitize( params.payload ), params.expected );
+              assert.contains( DOMPurify.sanitize( params.payload ), params.expected, 'Payload: ' + params.payload);
           });
 
         // Config-Flag Tests


### PR DESCRIPTION
I am working on fixing failing test cases in jsdom, but the output for many test cases is not very useful. Especially because a large amount of test cases have the same name. This change shows the following info when a case fails:

1. Show the actual output instead of "false"
2. Show a list of all valid expected values
3. Show the payload