### PR TITLE
Prevent DOM clobbering on <form> elements

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -184,6 +184,8 @@
     /* Ideally, do not touch anything below this line */
     /* ______________________________________________ */
 
+    var formElement = document.createElement('form');
+
     /**
      * _parseConfig
      *
@@ -448,7 +450,7 @@
             /* Make sure attribute cannot clobber */
             if (SANITIZE_DOM &&
                     (lcName === 'id' || lcName === 'name') &&
-                    (value in window || value in document)) {
+                    (value in window || value in document || value in formElement)) {
                 continue;
             }
 

--- a/test/expect.json
+++ b/test/expect.json
@@ -78,27 +78,27 @@
     {
         "title": "onsubmit, onfocus; DOM clobbering: children",
         "payload": "<form onsubmit=alert(1)><input onfocus=alert(2) name=children>123</form>",
-        "expected": ["", "<form><input name=\"children\">123</form>"]
+        "expected": ["", "<form><input>123</form>"]
     },
     {
         "title": "onsubmit, onfocus; DOM clobbering: attributes",
         "payload": "<form onsubmit=alert(1)><input onfocus=alert(2) name=attributes>123</form>",
-        "expected": ""
+        "expected": ["", "<form><input>123</form>"]
     },
     {
         "title": "onsubmit, onfocus; DOM clobbering: removeChild",
         "payload": "<form onsubmit=alert(1)><input onfocus=alert(2) name=removeChild>123</form>",
-        "expected": ""
+        "expected": ["", "<form><input>123</form>"]
     },
     {
         "title": "onsubmit, onfocus; DOM clobbering: removeAttributeNode",
         "payload": "<form onsubmit=alert(1)><input onfocus=alert(2) name=removeAttributeNode>123</form>",
-        "expected": ""
+        "expected": ["", "<form><input>123</form>"]
     },
     {
         "title": "onsubmit, onfocus; DOM clobbering: setAttribute",
         "payload": "<form onsubmit=alert(1)><input onfocus=alert(2) name=setAttribute>123</form>",
-        "expected": ""
+        "expected": ["", "<form><input>123</form>"]
     },
     {
         "title": "&gt;style&lt;",
@@ -991,5 +991,15 @@
         "title": "Removing name attr from img with id can crash Safari",
         "payload": "<img name=\"bar\" id=\"foo\">",
         "expected": "<img id=\"foo\" name=\"bar\">"
+    },
+    {
+        "title": "DOM clobbering: submit",
+        "payload": "<input name=submit>123",
+        "expected": "<input>123"
+    },
+    {
+        "title": "DOM clobbering: acceptCharset",
+        "payload": "<input name=acceptCharset>123",
+        "expected": "<input>123"
     }
 ]


### PR DESCRIPTION
This issue might be hit if you display sanitized html within your own `<form>` element.

For example:

```html
<form id="test">
    <script>
        document.write(DOMPurify.sanitize('<input name=submit>123'));
    </script>
</form>
<script>
    test.submit(); // TypeError: test.submit is not a function
</script>
```