### PR TITLE
Support for custom `window`

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "browser": true,
+  "browser": false,
   "curly": true,
   "eqeqeq": true,
   "expr": true,
@@ -7,11 +7,5 @@
   "smarttabs": true,
   "strict": true,
   "undef": true,
-  "unused": true,
-  "globals": {
-    "Attr": false,
-    "define": false,
-    "DocumentFragment": false,
-    "HTMLCollection": false
-  }
+  "unused": true
 }

--- a/purify.js
+++ b/purify.js
@@ -1,24 +1,46 @@
-/* global Text, module */
-;(function(root, factory) {
+;(function(factory) {
     'use strict';
+    /* global window: false, define: false, module: false */
+    var root = typeof window === 'undefined' ? null : window;
+
     if (typeof define === 'function' && define.amd) {
-        define(factory);
+        define(function(){ return factory(root); });
     } else if (typeof module !== 'undefined') {
-        module.exports = factory();
+        module.exports = factory(root);
     } else {
-        root.DOMPurify = factory();
+        root.DOMPurify = factory(root);
     }
-}(this, function() {
+}(function factory(window) {
     'use strict';
 
-    var DOMPurify = {};
-    var hooks = {};
+    var DOMPurify = function(window) {
+        return factory(window);
+    };
 
     /**
      * Version label, exposed for easier checks
      * if DOMPurfy is up to date or not
      */
     DOMPurify.version = '0.6.3';
+
+    if (!window || !window.document || window.document.nodeType !== 9) {
+        // not running in a browser, provide a factory function
+        // so that you can pass your own Window
+        DOMPurify.isSupported = false;
+        return DOMPurify;
+    }
+
+    var document = window.document;
+    var HTMLHtmlElement = window.HTMLHtmlElement;
+    var DocumentFragment = window.DocumentFragment;
+    var HTMLBodyElement = window.HTMLBodyElement;
+    var HTMLCollection = window.HTMLCollection;
+    var HTMLTemplateElement = window.HTMLTemplateElement;
+    var NodeFilter = window.NodeFilter;
+    var NodeList = window.NodeList;
+    var Text = window.Text;
+
+    var hooks = {};
 
     /**
      * Expose whether this browser supports running the full DOMPurify.

--- a/purify.js
+++ b/purify.js
@@ -19,7 +19,7 @@
 
     /**
      * Version label, exposed for easier checks
-     * if DOMPurfy is up to date or not
+     * if DOMPurify is up to date or not
      */
     DOMPurify.version = '0.6.3';
 

--- a/purify.js
+++ b/purify.js
@@ -1,4 +1,3 @@
-/* jshint boss: true */
 /* global Text, module */
 ;(function(root, factory) {
     'use strict';
@@ -490,7 +489,7 @@
         /* Execute a hook if present */
         _executeHook('beforeSanitizeShadowDOM', fragment, null);
 
-        while (shadowNode = shadowIterator.nextNode()) {
+        while ( (shadowNode = shadowIterator.nextNode()) ) {
             /* Execute a hook if present */
             _executeHook('uponSanitizeShadowNode', shadowNode, null);
 
@@ -564,7 +563,7 @@
         var nodeIterator = _createIterator(body);
 
         /* Now start iterating over the created document */
-        while (currentNode = nodeIterator.nextNode()) {
+        while ( (currentNode = nodeIterator.nextNode()) ) {
             /* Sanitize tags and elements */
             if (_sanitizeElements(currentNode)) {
                 continue;

--- a/test/index.html
+++ b/test/index.html
@@ -188,6 +188,23 @@
             assert.equal( typeof DOMPurify.isSupported, 'boolean' );
         });
 
+        QUnit.test( 'DOMPurify custom window tests', function(assert) {
+            assert.strictEqual(typeof DOMPurify(null).version, 'string');
+            assert.strictEqual(DOMPurify(null).isSupported, false);
+            assert.strictEqual(DOMPurify(null).sanitize, undefined);
+
+            assert.strictEqual(typeof DOMPurify({}).version, 'string');
+            assert.strictEqual(DOMPurify({}).isSupported, false);
+            assert.strictEqual(DOMPurify({}).sanitize, undefined);
+
+            assert.strictEqual(typeof DOMPurify({document: 'not really a document'}).version, 'string');
+            assert.strictEqual(DOMPurify({document: 'not really a document'}).isSupported, false);
+            assert.strictEqual(DOMPurify({document: 'not really a document'}).sanitize, undefined);
+
+            assert.strictEqual(typeof DOMPurify(window).version, 'string');
+            assert.strictEqual(typeof DOMPurify(window).sanitize, 'function');
+        });
+
         // Fire it up!
         QUnit.start();
       });


### PR DESCRIPTION
This change lets you set up DOMPurify with your own `window` and `document`. It is now super easy to set up with [jsdom](https://www.npmjs.com/package/jsdom):

```javascript
var document = require('jsdom').jsdom();
var DOMPurify = require('dompurify')(document.defaultView);
console.log(DOMPurify.sanitize('<script>alert("hi");</script><p>hello</p>'));
```

For the extra paranoid, you can put jsdom in a mode wherein it never download or execute scripts:
```javascript
var document = require('jsdom').jsdom('', {
    FetchExternalResources: false,
    ProcessExternalResources: false
});
```

This change is backwards compatible. If you run it in a browser, a `DOMPurify` object is added to the `window`. If you use browserify the following should work exactly like it did before: `require('dompurify').sanitize('...')`. I have never used AMD, so could someone double check that it still works as before?

Another fun thing you can do is browserify jsdom. This might be useful if there is some kind of strange browser that manages to run jsdom, but not DOMPurify (which I doubt, since jsdom uses ES6).