### PR TITLE
Add a few more missing legacy attributes

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -118,12 +118,12 @@
 
         // HTML
         'accept','action','align','alt','autocomplete','background','bgcolor',
-        'border','cellpadding','cellspacing','checked','cite','class','color',
+        'border','cellpadding','cellspacing','checked','cite','class','clear','color',
         'cols','colspan','coords','datetime','default','dir','disabled',
-        'download','enctype','for','headers','height','hidden','high','href',
+        'download','enctype','face','for','headers','height','hidden','high','href',
         'hreflang','id','ismap','label','lang','list','loop', 'low','max',
-        'maxlength','media','method','min','multiple','name','novalidate',
-        'open','optimum','pattern','placeholder','poster','preload','pubdate',
+        'maxlength','media','method','min','multiple','name','noshade','novalidate',
+        'nowrap','open','optimum','pattern','placeholder','poster','preload','pubdate',
         'radiogroup','readonly','rel','required','rev','reversed','rows',
         'rowspan','spellcheck','scope','selected','shape','size','span',
         'srclang','start','src','step','style','summary','tabindex','title',


### PR DESCRIPTION
* `<br clear="both" />`
* `<font face="Arial"></font>`
* `<hr noshade />`
* `<span nowrap>no wrap</span>`

I went through this list: http://www.w3.org/TR/html4/index/attributes.html

Ones I didn't add that seemed maybe reasonable:

* [ ] target (a)

----

* [ ] frame (table)
* [ ] axis  (table)
* [ ] charoff (table)
* [ ] char (table)
* [ ] rules (table)
* [ ] headers (table)
* [ ] charset (table)

----

* [ ] link (body)
* [ ] alink (body)
* [ ] vlink (body)
* [ ] text (body)

----

* [ ] version (html)
* [ ] profile (head)
* [ ] scheme (meta)
* [ ] content (meta)
* [ ] http-equiv (meta)

Other legacy things we should probably not add:

* [ ] compact
* [ ] prompt
* [ ] longdesc
* [ ] accesskey

----

* [ ] noresize (iframe)
* [ ] scrolling (iframe)
* [ ] marginwidth (iframe)
* [ ] frameborder (iframe)
* [ ] marginheight (iframe)

----

* [ ] language (script)
* [ ] defer (script)

----

* [ ] code     (object)
* [ ] classid  (object)
* [ ] data (object)
* [ ] hspace (object)
* [ ] vspace (object)
* [ ] codetype (object)
* [ ] valuetype (object)
* [ ] declare (object)
* [ ] codebase (object)
* [ ] archive (object)
* [ ] object (object)
* [ ] standby (object)