### PR TITLE
RETURN_DOM_FRAGMENT and RETURN_DOM_IMPORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,11 @@ var clean = DOMPurify.sanitize(dirty, {ADD_ATTR: ['my-attr']});
 // prohibit HTML5 data attributes (default is true)
 var clean = DOMPurify.sanitize(dirty, {ALLOW_DATA_ATTR: false});
 
-// return a DOM instead of an HTML string (default is false)
+// return a DOM HTMLBodyElement instead of an HTML string (default is false)
 var clean = DOMPurify.sanitize(dirty, {RETURN_DOM: true});
+
+// return a DOM DocumentFragment instead of an HTML string (default is false)
+var clean = DOMPurify.sanitize(dirty, {RETURN_DOM_FRAGMENT: true});
 
 // return entire document including <html> tags (default is false)
 var clean = DOMPurify.sanitize(dirty, {WHOLE_DOCUMENT: true});

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ var clean = DOMPurify.sanitize(dirty, {RETURN_DOM: true});
 // return a DOM DocumentFragment instead of an HTML string (default is false)
 var clean = DOMPurify.sanitize(dirty, {RETURN_DOM_FRAGMENT: true});
 
+// return a DOM DocumentFragment instead of an HTML string (default is false)
+// also import it into the current document (default is false).
+// RETURN_DOM_IMPORT must be set if you would like to append
+// the returned node to the current document
+var clean = DOMPurify.sanitize(dirty, {RETURN_DOM_FRAGMENT: true, RETURN_DOM_IMPORT: true});
+document.body.appendChild(clean);
+
 // return entire document including <html> tags (default is false)
 var clean = DOMPurify.sanitize(dirty, {WHOLE_DOCUMENT: true});
 

--- a/purify.js
+++ b/purify.js
@@ -31,6 +31,10 @@
     }
 
     var document = window.document;
+    var documentImplementation = document.implementation;
+    var createElement = document.createElement;
+    var createNodeIterator = document.createNodeIterator;
+    var importNode = document.importNode;
     var HTMLHtmlElement = window.HTMLHtmlElement;
     var DocumentFragment = window.DocumentFragment;
     var HTMLBodyElement = window.HTMLBodyElement;
@@ -45,7 +49,7 @@
      * Expose whether this browser supports running the full DOMPurify.
      */
     DOMPurify.isSupported =
-        typeof document.implementation.createHTMLDocument !== 'undefined' &&
+        typeof documentImplementation.createHTMLDocument !== 'undefined' &&
         document.documentMode !== 9;
 
     /* Add properties to a lookup table */
@@ -215,7 +219,7 @@
     /* Ideally, do not touch anything below this line */
     /* ______________________________________________ */
 
-    var formElement = document.createElement('form');
+    var formElement = createElement.call(document, 'form');
 
     /**
      * _parseConfig
@@ -282,7 +286,7 @@
      */
     var _initDocument = function(dirty) {
         /* Create documents to map markup to */
-        var dom = document.implementation.createHTMLDocument('');
+        var dom = documentImplementation.createHTMLDocument('');
         var freshdom, doc;
 
         /* Set content */
@@ -294,7 +298,7 @@
         body = WHOLE_DOCUMENT ? dom.body.parentNode : dom.body;
         if (!(body instanceof (WHOLE_DOCUMENT ? HTMLHtmlElement : HTMLBodyElement))) {
             doc = (typeof HTMLTemplateElement === 'function') ?
-                document.createElement('template').content.ownerDocument :
+                createElement.call(document, 'template').content.ownerDocument :
                 document;
             freshdom = doc.implementation.createHTMLDocument('');
             body = WHOLE_DOCUMENT ?
@@ -311,7 +315,8 @@
      * @return iterator instance
      */
     var _createIterator = function(doc) {
-        return document.createNodeIterator(
+        return createNodeIterator.call(
+            document,
             doc,
             NodeFilter.SHOW_ELEMENT
             | NodeFilter.SHOW_COMMENT
@@ -631,7 +636,7 @@
                    in theory but we would rather not risk another attack vector.
                    The state that is cloned by importNode() is explicitly defined
                    by the specs. */
-                returnNode = document.importNode(document, returnNode, true);
+                returnNode = importNode.call(document, returnNode, true);
             }
 
             return returnNode;

--- a/purify.js
+++ b/purify.js
@@ -185,6 +185,12 @@
     /* Decide if a DOM `DocumentFragment` should be returned, instead of a html string */
     var RETURN_DOM_FRAGMENT = false;
 
+    /* If `RETURN_DOM` or `RETURN_DOM_FRAGMENT` is enabled, decide if the returned DOM
+     * `Node` is imported into the current `Document`. If this flag is not enabled the
+     * `Node` will belong (its ownerDocument) to a fresh `HTMLDocument`, created by
+     * DOMPurify. */
+    var RETURN_DOM_IMPORT = false;
+
     /* Output should be free from DOM clobbering attacks? */
     var SANITIZE_DOM = true;
 
@@ -236,6 +242,7 @@
         WHOLE_DOCUMENT      = cfg.WHOLE_DOCUMENT      ||  false; // Default false
         RETURN_DOM          = cfg.RETURN_DOM          ||  false; // Default false
         RETURN_DOM_FRAGMENT = cfg.RETURN_DOM_FRAGMENT ||  false; // Default false
+        RETURN_DOM_IMPORT   = cfg.RETURN_DOM_IMPORT   ||  false; // Default false
         SANITIZE_DOM        = cfg.SANITIZE_DOM        !== false; // Default true
         KEEP_CONTENT        = cfg.KEEP_CONTENT        !== false; // Default true
 
@@ -616,6 +623,15 @@
                 }
             } else {
                 returnNode = body;
+            }
+
+            if (RETURN_DOM_IMPORT) {
+                /* adoptNode() is not used because internal state is not reset
+                   (e.g. the past names map of a HTMLFormElement), this is safe
+                   in theory but we would rather not risk another attack vector.
+                   The state that is cloned by importNode() is explicitly defined
+                   by the specs. */
+                returnNode = document.importNode(document, returnNode, true);
             }
 
             return returnNode;

--- a/test/index.html
+++ b/test/index.html
@@ -133,6 +133,16 @@
             assert.equal( DOMPurify.sanitize( '123', {RETURN_DOM: true}).outerHTML, "<body>123</body>" );
         });
 
+        QUnit.test( 'Config-Flag tests: RETURN_DOM_IMPORT', function(assert) {
+            //RETURN_DOM_IMPORT
+            assert.notEqual( DOMPurify.sanitize( '123', {RETURN_DOM         : true                          }).ownerDocument, document );
+            assert.notEqual( DOMPurify.sanitize( '123', {RETURN_DOM         : true, RETURN_DOM_IMPORT: false}).ownerDocument, document );
+            assert.equal   ( DOMPurify.sanitize( '123', {RETURN_DOM         : true, RETURN_DOM_IMPORT: true }).ownerDocument, document );
+            assert.notEqual( DOMPurify.sanitize( '123', {RETURN_DOM_FRAGMENT: true                          }).ownerDocument, document );
+            assert.notEqual( DOMPurify.sanitize( '123', {RETURN_DOM_FRAGMENT: true, RETURN_DOM_IMPORT: false}).ownerDocument, document );
+            assert.equal   ( DOMPurify.sanitize( '123', {RETURN_DOM_FRAGMENT: true, RETURN_DOM_IMPORT: true }).ownerDocument, document );
+        });
+
         QUnit.test( 'Config-Flag tests: RETURN_DOM_FRAGMENT', function(assert) {
             //RETURN_DOM_FRAGMENT
 

--- a/test/index.html
+++ b/test/index.html
@@ -230,6 +230,26 @@
             assert.strictEqual(typeof DOMPurify(window).version, 'string');
             assert.strictEqual(typeof DOMPurify(window).sanitize, 'function');
         });
+        QUnit.test( 'sanitize() should not throw if the original document is clobbered _after_ DOMPurify has been instantiated', function(assert) {
+                var evilNode = document.createElement('div');
+                evilNode.innerHTML = '<img id="implementation"><img id="createNodeIterator"><img id="importNode"><img id="createElement">';
+                document.body.appendChild(evilNode);
+                try {
+                        // tests implementation and createNodeIterator
+                        var resultPlain =  DOMPurify.sanitize('123');
+                        // tests importNode
+                        var resultImport = DOMPurify.sanitize( '123', {RETURN_DOM : true, RETURN_DOM_IMPORT: true });
+                        // tests createElement
+                        var resultBody = DOMPurify.sanitize( '123<img id="body">');
+                } finally {
+                        // clean up before doing the actual assertions, otherwise qunit/jquery/etc might blow up
+                        document.body.removeChild(evilNode);
+                }
+
+                assert.equal( resultPlain, '123' );
+                assert.equal( resultImport.ownerDocument, document );
+                assert.equal( resultBody, '123<img>' );
+        } );
 
         // Fire it up!
         QUnit.start();

--- a/test/index.html
+++ b/test/index.html
@@ -133,6 +133,22 @@
             assert.equal( DOMPurify.sanitize( '123', {RETURN_DOM: true}).outerHTML, "<body>123</body>" );
         });
 
+        QUnit.test( 'Config-Flag tests: RETURN_DOM_FRAGMENT', function(assert) {
+            //RETURN_DOM_FRAGMENT
+
+            // attempt clobbering
+            var fragment = DOMPurify.sanitize( 'foo<img id="createDocumentFragment">', {RETURN_DOM_FRAGMENT: true});
+            assert.equal(fragment.nodeType, 11);
+            assert.notEqual(fragment.ownerDocument, document);
+            assert.equal(fragment.firstChild && fragment.firstChild.nodeValue, 'foo');
+
+            // again, but without SANITIZE_DOM
+            fragment = DOMPurify.sanitize( 'foo<img id="createDocumentFragment">', {RETURN_DOM_FRAGMENT: true, SANITIZE_DOM: false});
+            assert.equal(fragment.nodeType, 11);
+            assert.notEqual(fragment.ownerDocument, document);
+            assert.equal(fragment.firstChild && fragment.firstChild.nodeValue, 'foo');
+        });
+
         QUnit.test( 'Config-Flag tests: FORBID_TAGS', function(assert) {
             //FORBID_TAGS
             assert.equal( DOMPurify.sanitize( '<a>123<b>456</b></a>', {FORBID_TAGS: ['b']}), "<a>123456</a>" );


### PR DESCRIPTION
Fixes #62

Should work properly even if `SANITIZE_DOM` is disabled.

```javascript
document.body.appendChild(
    DOMPurify.sanitize(dirty, {RETURN_DOM_FRAGMENT: true, RETURN_DOM_IMPORT: true})
);
```