### PR TITLE
Fix checking attributes type in FF22-34.

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -36,7 +36,7 @@
     var HTMLBodyElement = window.HTMLBodyElement;
     var HTMLTemplateElement = window.HTMLTemplateElement;
     var NodeFilter = window.NodeFilter;
-    var NamedNodeMap = window.NamedNodeMap;
+    var NamedNodeMap = window.NamedNodeMap || window.MozNamedAttrMap;
     var Text = window.Text;
 
     var hooks = {};


### PR DESCRIPTION
For a while, Firefox made the attributes collection an instance of
MozNamedAttrMap instead of NamedNodeMap.