### PR TITLE
Ensure document has blank web-components registry

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -101,8 +101,8 @@
         QUnit.test( 'Config-Flag tests: SANITIZE_DOM', function(assert) {
             // SANITIZE_DOM
             assert.equal( DOMPurify.sanitize( '<form name="window">', {SANITIZE_DOM: true}), "<form></form>" );
-            assert.equal( DOMPurify.sanitize( '<img src="x" name="implementation">', {SANITIZE_DOM: false}), "" );
-            assert.equal( DOMPurify.sanitize( '<img src="x" name="createNodeIterator">', {SANITIZE_DOM: false}), "" );
+            assert.equal( DOMPurify.sanitize( '<img src="x" name="implementation">', {SANITIZE_DOM: true}), '<img src="x">' );
+            assert.equal( DOMPurify.sanitize( '<img src="x" name="createNodeIterator">', {SANITIZE_DOM: true}), '<img src="x">' );
             assert.equal( DOMPurify.sanitize( '<img src="x" name="getElementById">', {SANITIZE_DOM: false}), "<img name=\"getElementById\" src=\"x\">" );
             assert.equal( DOMPurify.sanitize( '<img src="x" name="getElementById">', {SANITIZE_DOM: true}), "<img src=\"x\">" );
             assert.equal( DOMPurify.sanitize( '<a href="x" id="location">click</a>', {SANITIZE_DOM: true}), "<a href=\"x\">click</a>" );


### PR DESCRIPTION
Fixes #47 for real, I think. Unless I've misunderstood it, in which case please feel free to reject!

Also implements a better fix for clobbering of required fns on the dirty document; we cache direct references to the fns we need, so it doesn't matter if things get clobbered. This makes the SANITIZE_DOM option more consistent; the behaviour is the same for any name/id that would clobber a method/property in the document/window, regardless of whether we need it internally or not.