### PR TITLE
Fix import node + a variety of minor issues

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -313,7 +313,7 @@
      * @return iterator instance
      */
     var _createIterator = function(root) {
-        return createNodeIterator.call( root.ownerDocument || root,
+        return createNodeIterator.call(root.ownerDocument || root,
             root,
             NodeFilter.SHOW_ELEMENT
             | NodeFilter.SHOW_COMMENT

--- a/purify.js
+++ b/purify.js
@@ -31,6 +31,7 @@
     }
 
     var document = window.document;
+    var originalDocument = document;
     var DocumentFragment = window.DocumentFragment;
     var HTMLTemplateElement = window.HTMLTemplateElement;
     var NodeFilter = window.NodeFilter;
@@ -50,7 +51,8 @@
     var implementation = document.implementation;
     var createNodeIterator = document.createNodeIterator;
     var getElementsByTagName = document.getElementsByTagName;
-    var importNode = document.importNode;
+    var createDocumentFragment = document.createDocumentFragment;
+    var importNode = originalDocument.importNode;
 
     var hooks = {};
 
@@ -614,8 +616,7 @@
         if (RETURN_DOM) {
 
             if (RETURN_DOM_FRAGMENT) {
-                returnNode = Object.getPrototypeOf(body.ownerDocument)
-                        .createDocumentFragment.call(body.ownerDocument);
+                returnNode = createDocumentFragment.call(body.ownerDocument);
 
                 while (body.firstChild) {
                     returnNode.appendChild(body.firstChild);
@@ -630,7 +631,7 @@
                    in theory but we would rather not risk another attack vector.
                    The state that is cloned by importNode() is explicitly defined
                    by the specs. */
-                returnNode = importNode.call(document, returnNode, true);
+                returnNode = importNode.call(originalDocument, returnNode, true);
             }
 
             return returnNode;

--- a/purify.js
+++ b/purify.js
@@ -36,6 +36,7 @@
     var NodeFilter = window.NodeFilter;
     var NamedNodeMap = window.NamedNodeMap || window.MozNamedAttrMap;
     var Text = window.Text;
+    var Comment = window.Comment;
 
     // As per issue #47, the web-components registry is inherited by a
     // new document created via createHTMLDocument. As per the spec
@@ -330,7 +331,7 @@
      * @return true if clobbered, false if safe
      */
     var _isClobbered = function(elm) {
-        if (elm instanceof Text) {
+        if (elm instanceof Text || elm instanceof Comment) {
             return false;
         }
         if (

--- a/purify.js
+++ b/purify.js
@@ -458,7 +458,7 @@
             // remove a "name" attribute from an <img> tag that has an "id"
             // attribute at the time.
             if (lcName === 'name'  &&
-                    currentNode.nodeName === 'IMG' && currentNode.id) {
+                    currentNode.nodeName === 'IMG' && attributes.id) {
                 idAttr = attributes.id;
                 attributes = Array.prototype.slice.apply(attributes);
                 currentNode.removeAttribute('id');

--- a/purify.js
+++ b/purify.js
@@ -336,15 +336,12 @@
         if (elm instanceof Text || elm instanceof Comment) {
             return false;
         }
-        if (
-            (elm.outerHTML && typeof elm.outerHTML !== 'string')
-            || (elm.insertAdjacentHTML && typeof elm.insertAdjacentHTML !== 'function')
-            || typeof elm.nodeName !== 'string'
-            || typeof elm.textContent !== 'string'
-            || typeof elm.removeChild !== 'function'
-            || !(elm.attributes instanceof NamedNodeMap)
-            || typeof elm.removeAttribute !== 'function'
-            || typeof elm.setAttribute !== 'function'
+        if (  typeof elm.nodeName !== 'string'
+           || typeof elm.textContent !== 'string'
+           || typeof elm.removeChild !== 'function'
+           || !(elm.attributes instanceof NamedNodeMap)
+           || typeof elm.removeAttribute !== 'function'
+           || typeof elm.setAttribute !== 'function'
         ) {
             return true;
         }
@@ -354,8 +351,6 @@
     /**
      * _sanitizeElements
      *
-     * @protect outerHTML
-     * @protect insertAdjacentHTML
      * @protect nodeName
      * @protect textContent
      * @protect removeChild
@@ -389,8 +384,8 @@
         /* Remove element if anything forbids its presence */
         if (!ALLOWED_TAGS[tagName] || FORBID_TAGS[tagName]) {
             /* Keep content for white-listed elements */
-            if (KEEP_CONTENT && currentNode.insertAdjacentHTML
-                && CONTENT_TAGS[tagName]){
+            if (KEEP_CONTENT && CONTENT_TAGS[tagName]
+                    && typeof currentNode.insertAdjacentHTML === 'function' ){
                 try {
                     currentNode.insertAdjacentHTML('AfterEnd', currentNode.innerHTML);
                 } catch (e) {}


### PR DESCRIPTION
The main fix is for the importNode call, which I inadvertently broke when I fixed the clean document creation issue (#47). Also fixes comment nodes incorrectly being returned as clobbered, removes some more unnecessary clobber checks and does a better check for an id needed to workaround the Safari crash bug.