### PR TITLE
Accept non-alphanumeric data-* attributes

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -476,7 +476,10 @@
                 /* Check the name is permitted */
                 (
                  (ALLOWED_ATTR[lcName] && !FORBID_ATTR[lcName]) ||
-                 (ALLOW_DATA_ATTR && /^data-[\w-]+/.test(lcName))
+                 /* Allow potentially valid data-* attributes
+                    * At least one character after "-" (https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes)
+                    * XML-compatible (https://html.spec.whatwg.org/multipage/infrastructure.html#xml-compatible and http://www.w3.org/TR/xml/#d0e804) */
+                 (ALLOW_DATA_ATTR && /^data-[\w.\u00B7-\uFFFF-]/.test(lcName))
                 ) &&
                 /* Get rid of script and data URIs */
                 (
@@ -486,7 +489,7 @@
                   currentNode.nodeName === 'IMG')
                 )
             ) {
-                /* Handle invalid data attribute set by try-catching it */
+                /* Handle invalid data-* attribute set by try-catching it */
                 try {
                     currentNode.setAttribute(name, value);
                 } catch (e) {}

--- a/purify.js
+++ b/purify.js
@@ -418,10 +418,7 @@
         /* Check if we have attributes; if not we might have a text node */
         if (!attributes) { return; }
 
-        var isScriptOrData = /^(?:\w+script|data):/gi,
-            /* This needs to be extensive thanks to Webkit/Blink's behavior */
-            whitespace = /[\x00-\x20\xA0\u1680\u180E\u2000-\u2029\u205f\u3000]/g,
-            hookEvent = {
+        var hookEvent = {
                 attrName: '',
                 attrValue: '',
                 keepAttr: true
@@ -479,11 +476,11 @@
                  /* Allow potentially valid data-* attributes
                     * At least one character after "-" (https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes)
                     * XML-compatible (https://html.spec.whatwg.org/multipage/infrastructure.html#xml-compatible and http://www.w3.org/TR/xml/#d0e804) */
-                 (ALLOW_DATA_ATTR && /^data-[\w.\u00B7-\uFFFF-]/.test(lcName))
+                 (ALLOW_DATA_ATTR && DATA_ATTR.test(lcName))
                 ) &&
                 /* Get rid of script and data URIs */
                 (
-                 !isScriptOrData.test(value.replace(whitespace,'')) ||
+                 !IS_SCRIPT_OR_DATA.test(value.replace(ATTR_WHITESPACE,'')) ||
                  /* Keep image data URIs alive if src is allowed */
                  (lcName === 'src' && value.indexOf('data:') === 0 &&
                   currentNode.nodeName === 'IMG')
@@ -499,6 +496,10 @@
         /* Execute a hook if present */
         _executeHook('afterSanitizeAttributes', currentNode, null);
     };
+    var DATA_ATTR = /^data-[\w.\u00B7-\uFFFF-]/;
+    var IS_SCRIPT_OR_DATA = /^(?:\w+script|data):/i;
+    /* This needs to be extensive thanks to Webkit/Blink's behavior */
+    var ATTR_WHITESPACE = /[\x00-\x20\xA0\u1680\u180E\u2000-\u2029\u205f\u3000]/g;
 
     /**
      * _sanitizeShadowDOM

--- a/test/index.html
+++ b/test/index.html
@@ -70,6 +70,8 @@
                 ["<a data-abc-1-2-3=\"foo\" href=\"#\">abc</a>", "<a href=\"#\" data-abc-1-2-3=\"foo\">abc</a>"]
             );
             assert.equal( DOMPurify.sanitize( '<a href="#" data-""="foo">abc</a>', {ALLOW_DATA_ATTR: true}), "<a href=\"#\">abc</a>" );
+            assert.equal( DOMPurify.sanitize( '<a href="#" data-\u00B7._="foo">abc</a>', {ALLOW_DATA_ATTR: true}), "<a data-\u00B7._=\"foo\" href=\"#\">abc</a>" );
+            assert.equal( DOMPurify.sanitize( '<a href="#" data-\u00B5="foo">abc</a>', {ALLOW_DATA_ATTR: true}), "<a href=\"#\">abc</a>" );
         });
 
         QUnit.test( 'Config-Flag tests: ADD_TAGS', function(assert) {


### PR DESCRIPTION
HTML5 allows a broad range of characters for [data-* attribute names](https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes), but DOMPurify [further limits them](https://github.com/cure53/DOMPurify/blob/7a031e3232642acd8bbc952015d8c4c229cb40db/purify.js#L479) to alphanumerics, underscores, and hypens. This PR relaxes those and further relies on `setAttribute` to catch truly invalid names, and additionally avoids regex redefinition.