### PR TITLE
Fix form aliasing crash

### DIFF
--- a/purify.js
+++ b/purify.js
@@ -283,6 +283,19 @@
     };
 
    /**
+     * _forceRemove
+     *
+     * @param  a DOM node
+     */
+    var _forceRemove = function(node) {
+        try {
+            node.parentNode.removeChild(node);
+        } catch (e) {
+            node.outerHTML = '';
+        }
+    };
+
+   /**
      * _initDocument
      *
      * @param  a string of dirty markup
@@ -357,12 +370,7 @@
 
         /* Check if element is clobbered or can clobber */
         if (_isClobbered(currentNode)) {
-            /* Be harsh with clobbered content, element has to go! */
-            try {
-                currentNode.parentNode.removeChild(currentNode);
-            } catch (e) {
-                currentNode.outerHTML = '';
-            }
+            _forceRemove(currentNode);
             return true;
         }
 
@@ -383,12 +391,7 @@
                     currentNode.insertAdjacentHTML('AfterEnd', currentNode.innerHTML);
                 } catch (e) {}
             }
-            /* Force removal */
-            try {
-                currentNode.parentNode.removeChild(currentNode);
-            } catch (e) {
-                currentNode.outerHTML = '';
-            }
+            _forceRemove(currentNode);
             return true;
         }
 

--- a/purify.js
+++ b/purify.js
@@ -383,7 +383,12 @@
                     currentNode.insertAdjacentHTML('AfterEnd', currentNode.innerHTML);
                 } catch (e) {}
             }
-            currentNode.parentNode.removeChild(currentNode);
+            /* Force removal */
+            try {
+                currentNode.parentNode.removeChild(currentNode);
+            } catch (e) {
+                currentNode.outerHTML = '';
+            }
             return true;
         }
 

--- a/test/index.html
+++ b/test/index.html
@@ -57,6 +57,7 @@
             );
             assert.equal( DOMPurify.sanitize( '<a href="#">abc<b style="color:red">123</b><q class="cite">123</b></a>', {ALLOWED_TAGS: ['b', 'q'], ALLOWED_ATTR: ['style'], KEEP_CONTENT: false}), "");
             assert.equal( DOMPurify.sanitize( '<a href="#">abc</a>', {ALLOWED_TAGS: ['b', 'q'], KEEP_CONTENT: false}), "");
+            assert.equal( DOMPurify.sanitize( '<form><input name="parentNode"></form>', {ALLOWED_TAGS: ['input'], KEEP_CONTENT: true}), "<input>" );
         });
 
         QUnit.test( 'Config-Flag tests: ALLOW_DATA_ATTR', function(assert) {


### PR DESCRIPTION
Stripping out `<form>` elements with clobbered `parentNode` crashes DOMPurify.