### PR TITLE
Fix license requirement in bower.json to follow bower-license-spec.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,10 +18,10 @@
     "security",
     "secure"
   ],
-  "license": {
-    "type": "MPL-2.0 OR Apache-2.0",
-    "url": "https://github.com/cure53/DOMPurify/blob/master/LICENSE"
-  },
+  "license": [
+    "MPL-2.0",
+    "Apache-2.0"
+  ],
   "ignore": [
     "**/.*",
     "test",


### PR DESCRIPTION
Hi,

the [bower-license-spec](https://github.com/bower/bower.json-spec) specifies the license entry in the `bower.json` to be either a string, an array of strings or an url to the license file. Tools such as [bower-license](https://www.npmjs.com/package/bower-license) run into trouble when the spec is not followed.

I updated the `bower.json` the have a license entry of type array of strings. I hope it's possible for you guys to merge this back into master.

Cheers