### PR TITLE
Add sudo:false and fix jshint linting correct file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
 - '0.12'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "build-demo": "node scripts/build-demo.js",
     "qunit": "node scripts/server.js",
-    "jshint": "node node_modules/jshint/bin/jshint purify.js || true",
+    "jshint": "node node_modules/jshint/bin/jshint src/purify.js || true",
     "test": "npm run jshint;./node_modules/.bin/karma start test/karma.conf.js --single-run"
   },
   "devDependencies": {


### PR DESCRIPTION
- jshint now lints `src/purify.js`
- sudo:false flag addded to `travis.yml` for container-based infrastructure