### PR TITLE
Fix using purify.js from /src folder in demos and index.tpl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ DOMPurify sanitizes HTML and prevents XSS attacks. You can feed DOMPurify with s
 It's easy. Just include DOMPurify on your website.
 
 ```html
-<script type="text/javascript" src="purify.js"></script>
+<script type="text/javascript" src="src/purify.js"></script>
 ```
 
 Afterwards you can sanitize strings by executing the following code:

--- a/demos/advanced-config-demo.html
+++ b/demos/advanced-config-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
     </head>
     <body>
         <!-- Our DIV to receive content -->

--- a/demos/basic-demo.html
+++ b/demos/basic-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
     </head>
     <body>
         <!-- Our DIV to receive content -->

--- a/demos/config-demo.html
+++ b/demos/config-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
     </head>
     <body>
         <!-- Our DIV to receive content -->

--- a/demos/hooks-demo.html
+++ b/demos/hooks-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
     </head>
     <body>
         <!-- Our DIV to receive content -->

--- a/demos/hooks-link-proxy-demo.html
+++ b/demos/hooks-link-proxy-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
     </head>
     <body>
         <!-- Our DIV to receive content -->
@@ -12,9 +12,9 @@
             /* jshint globalstrict:true */
             /* global DOMPurify */
             'use strict';
-            
+
             var proxy = 'https://my.proxy.service/?';
-            
+
             // Specify dirty HTML
             var dirty = '<a href="http://evil.com/">CLICK</a>\
                          <a href="http://evil.com/" target="jajaja">CLICK</a>\
@@ -25,24 +25,24 @@
                          coords="0,0,200,200"></area></map>\
                          <math href="http://evil.com/">CLICKME</math>\
                          ';
-            
+
             // Add a hook to make all links point to a proxy
             DOMPurify.addHook('afterSanitizeAttributes', function(node){
                 // proxy form actions
                 if('action' in node){
-                    node.setAttribute('action', proxy 
+                    node.setAttribute('action', proxy
                         + encodeURIComponent(node.getAttribute('action')));
                 }
                 // proxy regular HTML links
                 if(node.hasAttribute('href')){
-                    node.setAttribute('href', proxy 
+                    node.setAttribute('href', proxy
                         + encodeURIComponent(node.getAttribute('href')));
-                }                
+                }
                 // proxy SVG/MathML links
                 if(node.hasAttribute('xlink:href')){
-                    node.setAttribute('xlink:href', proxy 
+                    node.setAttribute('xlink:href', proxy
                         + encodeURIComponent(node.getAttribute('xlink:href')));
-                } 
+                }
             });
 
             // Clean HTML string and write into our DIV

--- a/demos/hooks-mentaljs-demo.html
+++ b/demos/hooks-mentaljs-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
         <!--  Grab the latest version of MentalJS -->
         <script src="./lib/Mental.js"></script>
     </head>
@@ -14,10 +14,10 @@
             /* jshint globalstrict:true */
             /* global DOMPurify */
             'use strict';
-            
+
             // Initialize MentalJS
             MentalJS().init({dom: true});
-            
+
             // Specify dirty HTML
             var dirty = 'abc<script>alert(1)<\/script>\
                 <img src="xyz" onload="alert(2)">\
@@ -28,19 +28,19 @@
                 <script src=//evil.com>alert(5)<\/script>\
                 <svg><script xlink:href=//evil.com>alert(6)<\/script></svg>\
                 <svg><script href="//evil.com">123<\/script><p>';
-            
+
             // allow script elements
-            var config = { 
-                ADD_TAGS: ['script'], 
+            var config = {
+                ADD_TAGS: ['script'],
                 ADD_ATTR: ['onclick', 'onmouseover', 'onload', 'onunload']
-            }            
-            
+            }
+
             // Add a hook to sanitize all script content with MentalJS
             DOMPurify.addHook('uponSanitizeElement', function(node, data){
                 if(data.tagName === 'script'){
                     var script = node.textContent;
                     if(!script || 'src' in node.attributes
-                        || 'href' in node.attributes 
+                        || 'href' in node.attributes
                         || 'xlink:href' in node.attributes){
                             return node.parentNode.removeChild(node)
                     }
@@ -54,7 +54,7 @@
                     }
                 }
             });
-            
+
             // Add a hook to sanitize all white-listed events with MentalJS
             DOMPurify.addHook('uponSanitizeAttribute', function(node, data){
                 if(data.attrName.match(/^on\w+/)) {
@@ -67,7 +67,7 @@
                         return data.attrValue = '';
                     }
                 }
-            });            
+            });
 
             // Clean HTML string and write into our DIV
             var clean = DOMPurify.sanitize(dirty, config);

--- a/demos/hooks-proxy-demo.html
+++ b/demos/hooks-proxy-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
     </head>
     <body>
         <!-- Our DIV to receive content -->
@@ -18,7 +18,7 @@
                 var dirty = document.getElementById('payload').value;
 
                 // Specify proxy URL
-                var proxy = 'https://my.proxy/?url='; 
+                var proxy = 'https://my.proxy/?url=';
 
                 // What do we allow? Not much for now. But it's tight.
                 var config = {
@@ -138,11 +138,11 @@
                         }
                         // re-add styles in case any are left
                         if(output.length) {
-                            node.setAttribute('style', output.join(""));    
+                            node.setAttribute('style', output.join(""));
                         } else {
                             node.removeAttribute('style');
                         }
-                        
+
                     }
                 });
 
@@ -151,44 +151,44 @@
                 document.getElementById('sanitized').innerHTML = clean;
             }
         </script>
-        
+
         <!--  Here we cage our payload in a TEXTAREA -->
         <textarea id="payload">
             <!DOCTYPE html SYSTEM "https://leaking.via/doctype">
             <html xmlns="http://www.w3.org/1999/xhtml" manifest="https://leaking.via/html-manifest">
             <head>
-            
+
             <!--
             %Base (check manually)
             -->
             <base href="https://leaking.via/base-href/">
-            
+
             <!--
             %MSIE Imports
             -->
             <?IMPORT namespace="myNS" implementation="https://leaking.via/import-implementation" ?>
             <IMPORT namespace="myNS" implementation="https://leaking.via/import-implementation-2" />
-            
+
             <!--
             %Redirects
             -->
             <meta http-equiv="refresh" content="10; url=http://leaking.via/meta-refresh">
-            
-            <!--  
+
+            <!--
             %CSP
             -->
             <meta http-equiv="Content-Security-Policy" content="script-src 'self'; report-uri http://leaking.via/meta-csp-report-uri">
             <meta http-equiv="Content-Security-Policy-Report-Only" content="script-src 'self'; report-uri http://leaking.via/meta-csp-report-uri-2">
-            
-            <!-- 
+
+            <!--
             %Reading View
             -->
             <meta name="copyright" content="<img src='https://leaking.via/meta-name-copyright-reading-view'>">
             <meta name="displaydate" content="<img src='https://leaking.via/meta-name-displaydate-reading-view'>">
             <meta property="og:site_name" content="<img src='https://leaking.via/meta-property-reading-view'>">
-            
-            <!-- 
-            %Links 
+
+            <!--
+            %Links
             -->
             <link rel="stylesheet" href="https://leaking.via/link-stylesheet" />
             <link rel="icon" href="https://leaking.via/link-icon" />
@@ -200,16 +200,16 @@
             <link rel="prefetch" href="https://leaking.via/link-prefetch" />
             <link rel="preload" href="https://leaking.via/link-preload" />
             <link rel="prerender" href="https://leaking.via/link-prerender" />
-            
+
             <link rel="search" href="https://leaking.via/link-search" />
             <!--
             Note that OpenSearch description URLs are ignored in Chrome if this file isn't placed in the webroot.
             Also, in Chrome, you won't see the request in the developer tools because the request happens in the privileged browser process.
             Use a network sniffer to detect it.
             -->
-            
+
             <link rel="alternate" href="https://leaking.via/link-alternate" />
-            <link rel="alternate" type="application/atom+xml" href="https://leaking.via/link-alternate-atom" /> 
+            <link rel="alternate" type="application/atom+xml" href="https://leaking.via/link-alternate-atom" />
             <link rel="alternate stylesheet" href="https://leaking.via/link-alternate-stylesheet" />
             <link rel="appendix" href="https://leaking.via/link-appendix" />
             <link rel="apple-touch-icon-precomposed" href="https://leaking.via/link-apple-touch-icon-precomposed">
@@ -233,7 +233,7 @@
             <link rel="offline" href="https://leaking.via/link-offline" />
             <link rel="pingback" href="https://leaking.via/link-pingback" />
             <link rel="prev" href="https://leaking.via/link-prev" />
-            <link rel="search" type="application/opensearchdescription+xml" href="https://leaking.via/link-search-2" title="Search" /> 
+            <link rel="search" type="application/opensearchdescription+xml" href="https://leaking.via/link-search-2" title="Search" />
             <link rel="sidebar" href="https://leaking.via/link-sidebar" />
             <link rel="start" href="https://leaking.via/link-start" />
             <link rel="section" href="https://leaking.via/link-section" />
@@ -242,27 +242,27 @@
             <link rel="tag" href="https://leaking.via/link-tag" />
             <link rel="up" href="https://leaking.via/link-up" />
             </head>
-            
+
             <!--
             %Body Background
             -->
             <body background="https://leaking.via/body-background">
-            
-            <!-- 
+
+            <!--
             %Links & Maps
             -->
             <a ping="http://leaking.via/a-ping" href="#">You have to click me</a>
             <img src="data:;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw" width="150" height="150" usemap="#map">
             <map name="map">
               <area ping="http://leaking.via/area-ping" shape="rect" coords="0,0,150,150" href="#">
-            </map> 
-            <!-- 
-            The ping attribute allows to send a HTTP request to an external IP or domain, 
-            even if the link's HREF points somewhere else. The link has to be clicked though 
-            
+            </map>
+            <!--
+            The ping attribute allows to send a HTTP request to an external IP or domain,
+            even if the link's HREF points somewhere else. The link has to be clicked though
+
             https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping
             -->
-            
+
             <!--
             %Table Background
             -->
@@ -271,7 +271,7 @@
                     <td background="https://leaking.via/td-background"></td>
                 </tr>
             </table>
-            
+
             <!--
             %Images
             -->
@@ -279,15 +279,15 @@
             <img dynsrc="https://leaking.via/img-dynsrc">
             <img lowsrc="https://leaking.via/img-lowsrc">
             <img src="data:image/svg+xml,<svg%20xmlns='%68ttp:%2f/www.w3.org/2000/svg'%20xmlns:xlink='%68ttp:%2f/www.w3.org/1999/xlink'><image%20xlink:hr%65f='%68ttp:%2f/leaking.via/svg-via-data'></image></svg>">
-            
+
             <image src="https://leaking.via/image-src">
             <image href="https://leaking.via/image-href">
-            
+
             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <image href="https://leaking.via/svg-image-href">
             <image xlink:href="https://leaking.via/svg-image-xlink-href">
             </svg>
-            
+
             <picture>
                 <source srcset="https://leaking.via/picture-source-srcset">
             </picture>
@@ -295,10 +295,10 @@
                 <img srcset="https://leaking.via/picture-img-srcset">
             </picture>
             <img srcset=",,,,,https://leaking.via/img-srcset">
-            
+
             <img src="#" longdesc="https://leaking.via/img-longdesc">
             <!-- longdesc works on Firefox but requires right-click, "View Description" -->
-            
+
             <!--
             %Forms
             -->
@@ -308,7 +308,7 @@
             <form id="test"></form>
             <input type="image" src="https://leaking.via/input-src" name="test" value="test">
             <isindex src="https://leaking.via/isindex" type="image">
-            
+
             <!--
             %Media
             -->
@@ -323,7 +323,7 @@
               <source src="https://leaking.via/audio-source-src" type="video/mp4">
             </audio>
             <video poster="https://leaking.via/video-poster" src="https://leaking.via/video-poster-2"></video>
-            
+
             <!--
             %Object & Embed
             -->
@@ -339,15 +339,15 @@
             <object classid="clsid:333C7BC4-460F-11D0-BC04-0080C7055A83">
                 <param name="DataURL" value="http://leaking.via/object-param-dataurl">
             </object>
-            
-            
+
+
             <!--
             %Script
             -->
             <script src="https://leaking.via/script-src"></script>
             <svg><script href="https://leaking.via/svg-script-href"></script></svg>
             <svg><script xlink:href="https://leaking.via/svg-script-xlink-href"></script></svg>
-            
+
             <!--
             %Frames
             -->
@@ -358,8 +358,8 @@
                 <frame src="https://leaking.via/frame-src"></frame>
             </frameset>
             <iframe src="view-source:https://leaking.via/iframe-src-viewsource"></iframe>
-            
-            
+
+
             <!--
             %CSS
             -->
@@ -371,7 +371,7 @@
                 a:after {content: url(https://leaking.via/css-after-content)}
                 a::after {content: url(https://leaking.via/css-after-content-2)}
                 a:before {content: url(https://leaking.via/css-before-content)}
-                a::before {content: url(https://leaking.via/css-before-content-2)}    
+                a::before {content: url(https://leaking.via/css-before-content-2)}
             </style>
             <a href="#">ABC</a>
             <style>
@@ -418,7 +418,7 @@
                 }
                 s::after {
                   content: attr(foo url);
-                }    
+                }
                 s::before {
                   content: attr(notpresent, url(https://leaking.via/css-attr-fallback));
                 }
@@ -432,18 +432,18 @@
                   -webkit-animation-duration: 1s;
                 }
               }
-              
+
               @media some garbage {
                 more garbage;
               }
-              
+
               @-webkit-keyframes rotate-a-bit {
                 0% { transform: translate(0deg); background: url(https://leaking.via/keyframe-0) }
                 100% { transform: rotate(0deg); background: url(https://leaking.via/keyframe-100) }
               }
             </style>
-            
-            
+
+
             <!--
             %Inline CSS
             -->
@@ -457,7 +457,7 @@
                     shape-outside: url(https://leaking.via/inline-css-shape-outside);
                     cursor: url(https://leaking.via/inline-css-cursor), auto;
             ">JKL</b>
-            
+
             <svg>
             <circle style="
                     fill: url(https://leaking.via/svg-inline-css-fill#foo);
@@ -466,8 +466,8 @@
                     clip-path: url(https://leaking.via/svg-inline-css-clip-path#foo);
             "></circle>
             </svg>
-            
-            <!-- 
+
+            <!--
             %Exotic Inline CSS
             -->
             <div style="background: url() url() url() url() url(https://leaking.via/inline-css-multiple-backgrounds);"></div>
@@ -476,14 +476,14 @@
             <div style="background-image: image('https://leaking.via/inline-css-image-function')"></div>
             <div style="filter:progid:DXImageTransform.Microsoft.AlphaImageLoader( src='https://leaking.via/inline-css-filter-alpha', sizingMethod='scale');" ></div>
             <div style="filter:progid:DXImageTransform.Microsoft.ICMFilter(colorSpace='https://leaking.via/inline-css-filter-icm')"></div>
-            
+
             <!--
             %Applet
             -->
             <applet code="Test" codebase="https://leaking.via/applet-codebase"></applet>
             <applet code="Test" archive="https://leaking.via/applet-archive"></applet>
             <applet code="Test" object="https://leaking.via/applet-object"></applet>
-            
+
             <!--
             %SVG
             -->
@@ -500,24 +500,24 @@
               <rect x="0" y="0" width="200" height="200" fill="green" />
               <rect x="0" y="0" width="200" height="200" fill="red" mask="url(https://leaking.via/svg-mask)" />
             </svg>
-            
+
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <image xmlns:xlink="http://www.w3.org/1999/xlink">
                     <set attributeName="xlink:href" begin="0s" to="https://leaking.via/svg-image-set" />
                 </image>
             </svg>
-            
+
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <image xmlns:xlink="http://www.w3.org/1999/xlink">
                     <animate attributeName="xlink:href" begin="0s" from="#" to="https://leaking.via/svg-image-animate" />
                 </image>
             </svg>
-            
+
             <!--
             %XSLT Stylesheets
             -->
             <?xml-stylesheet type="text/xsl" href="https://leaking.via/xslt-stylesheet" ?>
-            
+
             <!--
             %Data Islands
             -->

--- a/demos/hooks-removal-demo.html
+++ b/demos/hooks-removal-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
     </head>
     <body>
         <!-- Our DIV to receive content -->
@@ -30,10 +30,10 @@
             // Clean HTML string and write into our DIV
             var clean = DOMPurify.sanitize(dirty);
             document.getElementById('sanitized').innerHTML += clean;
-            
+
             // now let's remove the hook again
             console.log(DOMPurify.removeHook('beforeSanitizeAttributes'));
-            
+
             // Clean HTML string and write into our DIV
             var clean = DOMPurify.sanitize(dirty);
             document.getElementById('sanitized').innerHTML += clean;
@@ -62,21 +62,21 @@
                     node.textContent=node.textContent.bold();
                 }
             });
-            
+
             // Clean HTML string and write into our DIV
             var clean = DOMPurify.sanitize(dirty);
             document.getElementById('sanitized').innerHTML += clean;
-            
+
             // now let's remove the hook again
             console.log(DOMPurify.removeHooks('beforeSanitizeAttributes'));
-            
+
             // Clean HTML string and write into our DIV
             var clean = DOMPurify.sanitize(dirty);
             document.getElementById('sanitized').innerHTML += clean;
-            
+
             /**
              * Add two hooks, then remove them using removeAllHooks()
-             * 
+             *
              * Keep in mind, we still have one from above, the .bold() hook
              */
             // Add a hook to convert all text to capitals
@@ -92,15 +92,15 @@
                 if(node.nodeName && node.nodeName === '#text') {
                     node.textContent=node.textContent.big();
                 }
-            });            
-            
+            });
+
             // Clean HTML string and write into our DIV
             var clean = DOMPurify.sanitize(dirty);
             document.getElementById('sanitized').innerHTML += clean;
-            
+
             // now let's remove the hook again
             console.log(DOMPurify.removeAllHooks());
-            
+
             // Clean HTML string and write into our DIV
             var clean = DOMPurify.sanitize(dirty);
             document.getElementById('sanitized').innerHTML += clean;

--- a/demos/hooks-sanitize-css-demo.html
+++ b/demos/hooks-sanitize-css-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
     </head>
     <body>
         <!-- Our DIV to receive content -->
@@ -24,10 +24,10 @@
 
                 // Specify CSS property whitelist
                 var allowed_properties = [
-                    'color', 
+                    'color',
                     'background',
-                    'border', 
-                    'padding', 
+                    'border',
+                    'padding',
                     'margin',
                     'font-family',
                     'content',
@@ -56,7 +56,7 @@
 
                 /**
                  * Take CSS rules and analyze them, create string wrapper to
-                 * apply them to the DOM later on. Note that only selector rules 
+                 * apply them to the DOM later on. Note that only selector rules
                  * are supported right now
                  */
                 function addCSSRules(output, cssRules) {
@@ -110,7 +110,7 @@
                 document.getElementById('sanitized').innerHTML = clean;
             }
         </script>
-        
+
         <!--  Here we cage our payload in a TEXTAREA -->
         <textarea id="payload">
 
@@ -162,7 +162,7 @@
                     content: 'hola!';
                 }
             </style>
-            <strong>GHI</strong>            
+            <strong>GHI</strong>
         </textarea>
     </body>
 </html>

--- a/demos/hooks-scheme-whitelist.html
+++ b/demos/hooks-scheme-whitelist.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
     </head>
     <body>
         <!-- Our DIV to receive content -->
@@ -12,7 +12,7 @@
             /* jshint globalstrict:true */
             /* global DOMPurify */
             'use strict';
-            
+
             // Specify dirty HTML
             var dirty = '<a href="foo:?a">INSECURE</a>\
                          <a href="ftp://abc.de?a"">SECURE</a>\

--- a/demos/hooks-target-blank-demo.html
+++ b/demos/hooks-target-blank-demo.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <script src="../purify.js"></script>
+        <script src="../src/purify.js"></script>
     </head>
     <body>
         <!-- Our DIV to receive content -->
@@ -12,7 +12,7 @@
             /* jshint globalstrict:true */
             /* global DOMPurify */
             'use strict';
-            
+
             // Specify dirty HTML
             var dirty = '<a href="?a">CLICK</a>\
                          <a href="?a" target="jajaja">CLICK</a>\
@@ -26,7 +26,7 @@
                          <math><mi target="xxx" href="?mathml">CLICKME</mi></math>\
                          <svg xmlns:xlink="http://www.w3.org/2000/svg"><a xlink:href="?bla"><circle r=40></a></svg>\
                          ';
-            
+
             // Add a hook to make all links open a new window
             DOMPurify.addHook('afterSanitizeAttributes', function(node){
                 // set all elements owning target to target=_blank
@@ -34,8 +34,8 @@
                     node.setAttribute('target','_blank');
                 }
                 // set non-HTML/MathML links to xlink:show=new
-                if(!node.hasAttribute('target') 
-                    && (node.hasAttribute('xlink:href') 
+                if(!node.hasAttribute('target')
+                    && (node.hasAttribute('xlink:href')
                         || node.hasAttribute('href'))){
                     node.setAttribute('xlink:show', 'new');
                 }

--- a/website/index.tpl
+++ b/website/index.tpl
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <title>DOMPurify 0.6.7 "Sandhopper"</title>
-        <script src="https://rawgithub.com/cure53/DOMPurify/master/purify.js"></script>
+        <script src="https://rawgithub.com/cure53/DOMPurify/master/src/purify.js"></script>
         <!-- we don't actually need it - just to demo and test the $(html) sanitation -->
         <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
     </head>
@@ -46,11 +46,11 @@
         <hr>
         <!-- rendered test data goes in here -->
         <iframe src="about:blank" id="ifr" style="width:95%;height:100px"></iframe>
-        <textarea placeholder="Payload goes here, test me, test me hard!" id="x" style="width:95%;height:200px"><!-- 
-        The following block of HTML is a collection of test cases, attack vectors and hard-to-process HTML chunks. 
-        DOMPurify will take the whole bunch and sanitize it. If you don't see an "alert" pop up afterwards, it means it worked :) 
+        <textarea placeholder="Payload goes here, test me, test me hard!" id="x" style="width:95%;height:200px"><!--
+        The following block of HTML is a collection of test cases, attack vectors and hard-to-process HTML chunks.
+        DOMPurify will take the whole bunch and sanitize it. If you don't see an "alert" pop up afterwards, it means it worked :)
         -->
-        
+
         <%- examples %></textarea>
         <textarea placeholder="Here be the sanitized markup to inspect!" id="y" style="width:95%;height:200px"></textarea>
     </body>


### PR DESCRIPTION
This replaces all occurrences of `purify.js` to `src/purify.js` and therefore closes #97. Along furthermore removes all trailing whitespaces from demo files.