### PR TITLE
Oh seven

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -580,9 +580,8 @@
      * @param {Object} configuration object
      */
     DOMPurify.sanitize = function(dirty, cfg) {
-        /* Return empty string if no input is given */
         if (!dirty) {
-            return '';
+            dirty = '';
         }
 
         /* Check we can run. Otherwise fall back or ignore */

--- a/src/purify.js
+++ b/src/purify.js
@@ -303,17 +303,17 @@
      * @return a DOM, filled with the dirty markup
      */
     var _initDocument = function(dirty) {
-
         /* Create a HTML document using DOMParser */
-        var doc;
+        var doc, body;
         try {
             doc = new DOMParser().parseFromString(dirty, "text/html");
         } catch (e) {}
 
-        /* Some browsers throw, some browsers return null for the code above */
+        /* Some browsers throw, some browsers return null for the code above
+           DOMParser with text/html support is only in very recent browsers. */
         if (!doc){
             doc = implementation.createHTMLDocument('');
-            var body = doc.body;
+            body = doc.body;
             body.parentNode.removeChild(body.parentNode.firstElementChild);
             body.outerHTML = dirty;
         }
@@ -323,8 +323,8 @@
             return doc.getElementsByTagName(
                 WHOLE_DOCUMENT ? 'html' : 'body')[0];
         } else {
-            return getElementsByTagName.call(doc, 
-                WHOLE_DOCUMENT ? 'html' : 'body')[0];    
+            return getElementsByTagName.call(doc,
+                WHOLE_DOCUMENT ? 'html' : 'body')[0];
         }
     };
 
@@ -443,9 +443,9 @@
             attrName: '',
             attrValue: '',
             keepAttr: true
-        },
-        l = attributes.length,
-        attr, name, value, lcName, idAttr;
+        };
+        var l = attributes.length;
+        var attr, name, value, lcName, idAttr;
 
         /* Go backwards over all attributes; safely remove bad ones */
         while (l--) {

--- a/src/purify.js
+++ b/src/purify.js
@@ -32,7 +32,6 @@
 
     var document = window.document;
     var originalDocument = document;
-    var implementation = document.implementation;
     var DocumentFragment = window.DocumentFragment;
     var HTMLTemplateElement = window.HTMLTemplateElement;
     var NodeFilter = window.NodeFilter;
@@ -50,6 +49,7 @@
     if (typeof HTMLTemplateElement === 'function') {
         document = document.createElement('template').content.ownerDocument;
     }
+    var implementation = document.implementation;
     var createNodeIterator = document.createNodeIterator;
     var getElementsByTagName = document.getElementsByTagName;
     var createDocumentFragment = document.createDocumentFragment;

--- a/src/purify.js
+++ b/src/purify.js
@@ -61,7 +61,8 @@
      * Expose whether this browser supports running the full DOMPurify.
      */
     DOMPurify.isSupported =
-        typeof DOMParser !== 'undefined' && document.documentMode !== 9;
+        typeof implementation.createHTMLDocument !== 'undefined' &&
+        document.documentMode !== 9;
 
     /* Add properties to a lookup table */
     var _addToSet = function(set, array) {


### PR DESCRIPTION
A few small fixes and tidy.
* When the code to cache `document.implementation` was added back, it was in the wrong place so used the wrong `document`.
* Fix return type doesn't respect config if empty input string.
* Revert isSupported check since we fallback still for browsers without DOMParser support.