### PR TITLE
Add dots reporter to karma run on TravisCI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "minify": "scripts/minify.sh",
     "amend-minified": "scripts/amend-minified.sh",
     "test": "npm run jshint && npm run-script travis-ci",
-    "travis-ci": "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && ./node_modules/.bin/karma start test/karma.conf.js --single-run || false",
+    "travis-ci": "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && ./node_modules/.bin/karma start test/karma.conf.js --log-level warn --reporters dots --single-run || false",
     "ci-test": "./node_modules/.bin/karma start test/karma.conf.js --single-run",
     "local-test": "npm run jshint;./node_modules/.bin/karma start test/karma.conf.js --browsers Firefox,Chrome --single-run"
   },


### PR DESCRIPTION
> Less verbose logs for TravisCI run than previously produced by `progress` reporter.

This changes the log level to `warn` from `info` and adds the `dots` reporter to a karma run on TravisCI. The dots reporter is meant to be way less verbose.

Still I hope errors get reported nicely too. Still, the local run triggered by `npm run-script ci-test` will still make use of the `progress` reporter and therefore give more detailed output.