### PR TITLE
Improve code quality and robustness

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -652,7 +652,7 @@
         /* Stringify, in case dirty is an object */
         if (typeof dirty !== 'string') {
             if (typeof dirty.toString !== 'function') {
-                throw TypeError('toString is not a function');
+                throw new TypeError('toString is not a function');
             } else {
                 dirty = dirty.toString();
             }

--- a/src/purify.js
+++ b/src/purify.js
@@ -483,12 +483,11 @@
      * @return  void
      */
     var _sanitizeAttributes = function(currentNode) {
-        /* Execute a hook if present */
-        var hookEvent, l, attr, name, value, lcName, idAttr;
-        var attributes = currentNode.attributes;
-
+        var attr, name, value, lcName, idAttr, attributes, hookEvent, l;
         /* Execute a hook if present */
         _executeHook('beforeSanitizeAttributes', currentNode, null);
+
+        attributes = currentNode.attributes;
 
         /* Check if we have attributes; if not we might have a text node */
         if (!attributes) { return; }
@@ -499,6 +498,7 @@
             keepAttr: true
         };
         l = attributes.length;
+
         /* Go backwards over all attributes; safely remove bad ones */
         while (l--) {
             attr = attributes[l];
@@ -668,7 +668,7 @@
 
         /* Check we can run. Otherwise fall back or ignore */
         if (!DOMPurify.isSupported) {
-            if (typeof window.toStaticHTML === 'object'
+            if (typeof window.toStaticHTML === 'object' 
                 || typeof window.toStaticHTML === 'function') {
                 return window.toStaticHTML(dirty);
             }

--- a/src/purify.js
+++ b/src/purify.js
@@ -633,6 +633,13 @@
         });
     };
 
+    /**
+     * sanitize
+     * Public method providing core sanitation functionality
+     *
+     * @param {String} dirty string
+     * @param {Object} configuration object
+     */
     DOMPurify.sanitize = function(dirty, cfg) {
         var body, currentNode, oldNode, nodeIterator, returnNode;
         /* Make sure we have a string to sanitize.

--- a/src/purify.js
+++ b/src/purify.js
@@ -467,7 +467,7 @@
     };
 
     var DATA_ATTR = /^data-[\w.\u00B7-\uFFFF-]/;
-    var IS_ALLOWED_URI = /^(?:[\W\d]|(?:mailto|tel|(?:http|ftp)s?):|(?=([a-z]+))\1(?!:))/i;
+    var IS_ALLOWED_URI = /^(?:[^a-z]|(?:(?:f|ht)tps?|mailto|tel):|[a-z]+(?:[^a-z:]|$))/i;
     /* This needs to be extensive thanks to Webkit/Blink's behavior */
     var ATTR_WHITESPACE = /[\x00-\x20\xA0\u1680\u180E\u2000-\u2029\u205f\u3000]/g;
 
@@ -651,16 +651,8 @@
 
         /* Stringify, in case dirty is an object */
         if (typeof dirty !== 'string') {
-            if (Object.prototype.hasOwnProperty.call(dirty, 'toString')) {
-                if (dirty instanceof String ||
-                        Object.prototype.toString.call(dirty) === '[object String]') {
-                    dirty = String.prototype.toString.call(dirty);
-                } else if (dirty instanceof Array ||
-                               (Array.isArray && Array.isArray(dirty))) {
-                    dirty = Array.prototype.toString.call(dirty);
-                } else {
-                    dirty = Object.prototype.toString.call(dirty);
-                }
+            if (typeof dirty.toString !== 'function') {
+                throw TypeError('toString is not a function');
             } else {
                 dirty = dirty.toString();
             }


### PR DESCRIPTION
Hey, guys!

After taking an overview at DOMPurify, I have a few concerns. This pull request tries to address them as explained below:

At line no. 393 and its following line, you're clearly making use of the `m` modifier within these couple regular expressions: `/\{\{.*|.*\}\}/gm` and `/<%.*|.*%>/gm`; that, in fact, has absolutely no effect on the dot meta-character in ECMAScript! I guess you meant to match new lines with that (or line terminators `[\n\r\u2028\u2029]` in general), but the right way to do so is by using a character class as such `[\s\S]`.

Another concern is, at line no. 470, you're making use of a blacklist regex to detect evil URI schemes like `javascript:`, and you are doing it well (albeit, this has been bypassed before). But given that it will only match at the very beginning of a given string, I really wonder what would happen if some random browser doesn't mind evaluating something like `feed:javascript:alert(0)`? This has happened before with Firefox; no guarantee it wouldn't happen again! Not to mention other provisional URI schemes that might extend our attack surface here!

So, my proposed fix for that is to alternatively use this whitelist regex `/^(?:[\W\d]|(?=([a-z]+))\1(?!:)|(?:mailto|tel|(?:http|ftp)s?):)/i` instead--allowing only relative URIs and known good URI schemes like `mailto`, `http`, `ftps`, etc.

Furthermore, at line no. 653, DOMPurify invokes the `toString` method directly on a user-supplied argument (i.e. the `dirty` parameter). I don't think this is a good idea, as such methods are prone to be overridden hence introducing unexpected behaviors; we shouldn't generally be calling methods on arbitrary user-supplied objects without any kind of checks in place.

My proposed fix here is to first check whether our object argument has an overridden `toString` property or not; if so, we borrow a native `toString` method from the right prototype instead...implementing it accordingly for `String` instances (`String.prototype.toString.call(dirty)`), arrays (`Array.toString.call(dirty)`), and object literals (`Object.prototype.toString.call(dirty)`). Otherwise, we just invoke the `toString` method directly on the object, as it used to be.

Other than that, just a few convention corrections here and there!

Cheers (and thanks for creating DOMPurify!),