### PR TITLE
Also run unit tests using jsdom + Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "minify": "scripts/minify.sh",
     "amend-minified": "scripts/amend-minified.sh",
     "test": "npm run jshint && npm run-script travis-ci",
-    "travis-ci": "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && ./node_modules/.bin/karma start test/karma.conf.js --log-level warn --reporters dots --single-run || false",
+    "travis-ci": "[ \"${TRAVIS_PULL_REQUEST}\" != \"false\" ] || ./node_modules/.bin/karma start test/karma.conf.js --log-level warn --reporters dots --single-run || false",
     "ci-test": "./node_modules/.bin/karma start test/karma.conf.js --single-run",
     "local-test": "npm run jshint;./node_modules/.bin/karma start test/karma.conf.js --browsers Firefox,Chrome --single-run",
     "jsdom-test": "node test/jsdom-node-runner"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "npm run jshint && npm run-script travis-ci",
     "travis-ci": "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && ./node_modules/.bin/karma start test/karma.conf.js --log-level warn --reporters dots --single-run || false",
     "ci-test": "./node_modules/.bin/karma start test/karma.conf.js --single-run",
-    "local-test": "npm run jshint;./node_modules/.bin/karma start test/karma.conf.js --browsers Firefox,Chrome --single-run"
+    "local-test": "npm run jshint;./node_modules/.bin/karma start test/karma.conf.js --browsers Firefox,Chrome --single-run",
+    "jsdom-test": "node test/jsdom-node-runner"
   },
   "pre-commit": [
     "jshint",
@@ -16,6 +17,7 @@
     "amend-minified"
   ],
   "devDependencies": {
+    "jsdom": "^8.4.0",
     "jshint": "^2.4.4",
     "json-loader": "^0.5.2",
     "karma": "^0.13.15",
@@ -29,6 +31,7 @@
     "karma-webpack": "^1.7.0",
     "pre-commit": "^1.1.2",
     "qunit-parameterize": "^0.4.0",
+    "qunit-tap": "^1.5.0",
     "qunitjs": "^1.20.0",
     "uglify-js": "^2.5.0",
     "webpack": "^1.12.1"

--- a/test/fixtures/expect.js
+++ b/test/fixtures/expect.js
@@ -256,10 +256,10 @@ module.exports = [
       "payload": "<form action=\"javasc\nript:alert(1)\"><button>XXX</button></form>",
       "expected": "<form><button>XXX</button></form>"
   }, {
-      "payload": "<div id=\"1\"><form id=\"test\"></form><button form=\"test\" formaction=\"javascript:alert(1)\">X</button>//[\"'`-->]]>]</div>",
+      "payload": "<div id=\"1\"><form id=\"foobar\"></form><button form=\"foobar\" formaction=\"javascript:alert(1)\">X</button>//[\"'`-->]]>]</div>",
       "expected": [
-          "<div id=\"1\"><form></form><button>X</button>//[\"'`--&gt;]]&gt;]</div>",
-          "<div id=\"1\"><form><button>X</button>//[\"'`--&gt;]]&gt;]</form></div>"
+          "<div id=\"1\"><form id=\"foobar\"></form><button>X</button>//[\"'`--&gt;]]&gt;]</div>",
+          "<div id=\"1\"><form id=\"foobar\"><button>X</button>//[\"'`--&gt;]]&gt;]</form></div>"
       ]
   }, {
       "payload": "<div id=\"2\"><meta charset=\"x-imap4-modified-utf7\">&ADz&AGn&AG0&AEf&ACA&AHM&AHI&AGO&AD0&AGn&ACA&AG8Abg&AGUAcgByAG8AcgA9AGEAbABlAHIAdAAoADEAKQ&ACAAPABi//[\"'`-->]]>]</div>",
@@ -332,10 +332,10 @@ module.exports = [
       "payload": "<div id=\"22\"><input onblur=focus() autofocus><input>//[\"'`-->]]>]</div>",
       "expected": "<div id=\"22\"><input><input>//[\"'`--&gt;]]&gt;]</div>"
   }, {
-      "payload": "<div id=\"23\"><form id=test onforminput=alert(23)><input></form><button form=test onformchange=alert(2)>X</button>//[\"'`-->]]>]</div>",
+      "payload": "<div id=\"23\"><form id=foobar onforminput=alert(23)><input></form><button form=test onformchange=alert(2)>X</button>//[\"'`-->]]>]</div>",
       "expected": [
-          "<div id=\"23\"><form><input></form><button>X</button>//[\"'`--&gt;]]&gt;]</div>",
-          "<div id=\"23\"><form><input><button>X</button>//[\"'`--&gt;]]&gt;]</form></div>"
+          "<div id=\"23\"><form id=\"foobar\"><input></form><button>X</button>//[\"'`--&gt;]]&gt;]</div>",
+          "<div id=\"23\"><form id=\"foobar\"><input><button>X</button>//[\"'`--&gt;]]&gt;]</form></div>"
       ]
   }, {
       "payload": "<div id=\"24\">1<set/xmlns=`urn:schemas-microsoft-com:time` style=`behAvior:url(#default#time2)` attributename=`innerhtml` to=`<img/src=\"x\"onerror=alert(24)>`>//[\"'`-->]]>]</div>",

--- a/test/fixtures/expect.js
+++ b/test/fixtures/expect.js
@@ -406,6 +406,7 @@ module.exports = [
       "payload": "<!-- IE9+, FF4+, Opera 11.60+, Safari 4.0.4+, GC7+  -->\n<svg><![CDATA[><image xlink:href=\"]]><img src=x onerror=alert(2)//\"></svg>//[\"'`-->]]>]</div>",
       "expected": [
           "<svg>&gt;&lt;image xlink:href=\"</svg><img src=\"x\">//[\"'`--&gt;]]&gt;]",
+          "<svg>&gt;&lt;image xlink:href=\"<img src=\"x\"></svg>//[\"'`--&gt;]]&gt;]",
           "<svg>&gt;&lt;image xlink:href=\"<img src=\"x\"></img></svg>//[\"'`--&gt;]]&gt;]",
           "<svg xmlns=\"http://www.w3.org/2000/svg\">&gt;&lt;image xlink:href=\"</svg></svg><img src=\"x\">//[\"'`--&gt;]]&gt;]"
       ]
@@ -808,7 +809,8 @@ module.exports = [
       "expected": [
           "<div id=\"128\"><svg><style></style></svg><img src=\"x\">//[\"'`--&gt;]]&gt;]</div>",
           "<div id=\"128\"><svg><style><img src=\"x\">//[\"'`--&gt;]]&gt;]</img></style></svg></div>",
-          "<div id=\"128\"><svg xmlns=\"http://www.w3.org/2000/svg\"><style /></svg></svg><img src=\"x\">//[\"'`--&gt;]]&gt;]</div>"
+          "<div id=\"128\"><svg xmlns=\"http://www.w3.org/2000/svg\"><style /></svg></svg><img src=\"x\">//[\"'`--&gt;]]&gt;]</div>",
+          "<div id=\"128\"><svg><style><img src=\"x\"></style></svg></div>"
       ]
   }, {
       "title": "Inline SVG (data-uri)",

--- a/test/fixtures/expect.js
+++ b/test/fixtures/expect.js
@@ -6,7 +6,10 @@ module.exports = [
             "<svg><defs><filter id=\"f1\"><feGaussianBlur in=\"SourceGraphic\" stdDeviation=\"15\" /></filter></defs><rect width=\"90\" height=\"90\" stroke=\"green\" stroke-width=\"3\" fill=\"yellow\" filter=\"url(#f1)\" /></svg>",
             "<svg><defs><filter id=\"f1\"><feGaussianBlur stdDeviation=\"15\" in=\"SourceGraphic\"></feGaussianBlur></filter></defs><rect filter=\"url(#f1)\" fill=\"yellow\" stroke-width=\"3\" stroke=\"green\" height=\"90\" width=\"90\"></rect></svg>",
             "<svg xmlns=\"http://www.w3.org/2000/svg\"><defs><filter id=\"f1\"><feGaussianBlur in=\"SourceGraphic\" stdDeviation=\"15\" /></filter></defs><rect filter=\"url(&quot;#f1&quot;)\" fill=\"yellow\" stroke=\"green\" stroke-width=\"3\" width=\"90\" height=\"90\" /></svg>",
-            "<svg xmlns=\"http://www.w3.org/2000/svg\"><defs><filter id=\"f1\"><feGaussianBlur in=\"SourceGraphic\" stdDeviation=\"15\" /></filter></defs><rect filter=\"url(#f1)\" fill=\"yellow\" stroke=\"green\" stroke-width=\"3\" width=\"90\" height=\"90\" FILTER=\"url(#f1)\" /></svg>"
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"><defs><filter id=\"f1\"><feGaussianBlur in=\"SourceGraphic\" stdDeviation=\"15\" /></filter></defs><rect filter=\"url(#f1)\" fill=\"yellow\" stroke=\"green\" stroke-width=\"3\" width=\"90\" height=\"90\" FILTER=\"url(#f1)\" /></svg>",
+            // browsers without SVG support (notice the lowercase tagname):
+            "<svg><defs><filter id=\"f1\"><fegaussianblur in=\"SourceGraphic\" stdDeviation=\"15\" /></filter></defs><rect width=\"90\" height=\"90\" stroke=\"green\" stroke-width=\"3\" fill=\"yellow\" filter=\"url(#f1)\" /></svg>",
+            "<svg><defs><filter id=\"f1\"><fegaussianblur stdDeviation=\"15\" in=\"SourceGraphic\"></fegaussianblur></filter></defs><rect filter=\"url(#f1)\" fill=\"yellow\" stroke-width=\"3\" stroke=\"green\" height=\"90\" width=\"90\"></rect></svg>"
        ]
      },
   {

--- a/test/jsdom-node-runner.js
+++ b/test/jsdom-node-runner.js
@@ -1,0 +1,17 @@
+/* jshint node: true, esnext: true */
+/* global QUnit */
+'use strict';
+
+global.QUnit = require('qunitjs');
+const qunitTap = require('qunit-tap');
+
+qunitTap(QUnit, line => {
+    if (/^not ok/.test(line)) {
+        process.exitCode = 1;
+    }
+    console.log(line);
+});
+
+require('./jsdom-node');
+
+QUnit.load();

--- a/test/jsdom-node.js
+++ b/test/jsdom-node.js
@@ -1,0 +1,48 @@
+/* jshint node: true, esnext: true */
+/* global QUnit */
+'use strict';
+
+// Test DOMPurify + jsdom using Node.js (version 4 and up)
+const
+    dompurify = require('../'),
+    jsdom = require('jsdom'),
+    testSuite = require('./test-suite'),
+    tests = require('./fixtures/expect'),
+    xssTests = tests.filter( element => /alert/.test( element.payload ) );
+
+require('qunit-parameterize/qunit-parameterize');
+
+QUnit.assert.contains = function( needle, haystack, message ) {
+    const result = haystack.indexOf(needle) > -1;
+    this.push(result, needle, haystack, message);
+};
+
+QUnit.config.autostart = false;
+
+jsdom.env({
+    html: `<html><head></head><body><div id="qunit-fixture"></div></body></html>`,
+    scripts: ['bower_components/jQuery/dist/jquery.js'],
+    features: {
+        ProcessExternalResources: ["script"] // needed for firing the onload event for about:blank iframes
+    },
+    done(err, window) {
+        QUnit.module('DOMPurify in jsdom');
+        if (err) {
+            console.error('Unexpected error returned by jsdom.env():', err, err.stack);
+            process.exit(1);
+        }
+
+        const DOMPurify = dompurify(window);
+        if (!DOMPurify.isSupported) {
+            console.error('Unexpected error returned by jsdom.env():', err, err.stack);
+            process.exit(1);
+        }
+
+        window.alert = () => {
+            window.xssed = true;
+        };
+        
+        testSuite(DOMPurify, window, tests, xssTests);
+        QUnit.start();
+    }
+});

--- a/test/purify.min.spec.js
+++ b/test/purify.min.spec.js
@@ -7,4 +7,4 @@ var
   });
 
 QUnit.module('DOMPurify dist');
-testSuite(DOMPurify, tests, xssTests);
+testSuite(DOMPurify, window, tests, xssTests);

--- a/test/purify.spec.js
+++ b/test/purify.spec.js
@@ -7,4 +7,4 @@ var
   });
 
 QUnit.module('DOMPurify src');
-testSuite(DOMPurify, tests, xssTests);
+testSuite(DOMPurify, window, tests, xssTests);

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -1,4 +1,7 @@
-module.exports = function(DOMPurify, tests, xssTests) {
+module.exports = function(DOMPurify, window, tests, xssTests) {
+  var document = window.document;
+  var jQuery = window.jQuery;
+
   QUnit
     .cases(tests)
     .test( 'Sanitization test', function(params, assert) {


### PR DESCRIPTION
Also see #129

There is one failing test because of https://github.com/tmpvar/jsdom/issues/1460, which is why I have not yet added this new task to the CI script.

The new file `test/jsdom-node.js` is using ES6 syntax because jsdom requires that same syntax, so this test suite will fail early if someone tries to run it with a node.js version that is too old. I could easily change this if you all would like to enforce ES5 as a style requirement.

I am not that familiar with QUnit, so could someone double check that part? For example, is the `qunit` npm package a good runner for it? (I have noticed that it uses an older version of `qunitjs`, so we end up with two versions of `qunitjs`)