### PR TITLE
Update karma-browserstack-runner and fix karma log level

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "minify": "scripts/minify.sh",
     "amend-minified": "scripts/amend-minified.sh",
     "test": "npm run jshint && npm run travis-ci",
-    "travis-ci": "npm run jsdom-test && ([ \"${TRAVIS_PULL_REQUEST}\" != \"false\" ] || karma start test/karma.conf.js --log-level warn --reporters dots --single-run)",
+    "travis-ci": "npm run jsdom-test && ([ \"${TRAVIS_PULL_REQUEST}\" != \"false\" ] || karma start test/karma.conf.js --log-level error --reporters dots --single-run)",
     "ci-test": "karma start test/karma.conf.js --single-run",
     "local-test": "npm run jshint; npm run jsdom-test && karma start test/karma.conf.js --browsers Firefox,Chrome --single-run",
     "jsdom-test": "node test/jsdom-node-runner --dot"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jshint": "^2.9.2",
     "json-loader": "^0.5.4",
     "karma": "^0.13.22",
-    "karma-browserstack-launcher": "git://github.com/shirish87/karma-browserstack-launcher.git#global_poll_0.1.6",
+    "karma-browserstack-launcher": "1.0.0",
     "karma-chrome-launcher": "^1.0.1",
     "karma-firefox-launcher": "^1.0.0",
     "karma-fixture": "^0.2.6",


### PR DESCRIPTION
I ran all tests with node@4 on against another BrowserStack account and they all worked fine now three times in a row.

I am unsure why karma hangs with browser.on is not a function as it is mentioned in issues long merged and released. The update - away from the fork - of the karma-browserstack-launcher could maybe have caused dropping connection.

Let me know if this helps whenever your rate limits comes back to life. I hope you/we can find a sponsor for this project. Do you have any clue how much runs - build time this actually causes?