### PR TITLE
fix a bug

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -377,6 +377,8 @@
     var _initDocument = function(dirty) {
         /* Create a HTML document using DOMParser */
         var doc, body;
+
+        dirty = '<div></div>' + dirty;
         try {
             doc = new DOMParser().parseFromString(dirty, 'text/html');
         } catch (e) {}
@@ -390,6 +392,8 @@
             body.parentNode.removeChild(body.parentNode.firstElementChild);
             body.outerHTML = dirty;
         }
+
+        doc.body.removeChild(doc.body.firstElementChild);
 
         /* Work on whole document or just its body */
         if (typeof doc.getElementsByTagName === 'function') {


### PR DESCRIPTION
if `dirty` start with a tag(eg. `<style>`) which will be parsed into head by DOMParser,  the tag wiil disappear in result.



```
var dirty = '<style f="x"></style>aaa<style f="y"></style>';
const clean = DOMPurify.sanitize(dirty));
/*
 except       <style f="x"></style>aaa<style f="y"></style>
 but shows    aaa<style f="y"></style>
*/
```