### PR TITLE
Reduce package footprint

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,9 @@
   ],
   "ignore": [
     "**/.*",
+    "demos",
+    "scripts",
     "test",
-    "demo"
+    "website"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "test:ci": "npm run lint && npm run test:jsdom && (([ \"${TRAVIS_PULL_REQUEST}\" != \"false\" ] || [ \"${TEST_BROWSERSTACK}\" != \"true\" ]) || karma start test/karma.conf.js --log-level error --reporters dots --single-run)",
     "test": "npm run lint && npm run test:jsdom && npm run test:karma -- --browsers Firefox,Chrome"
   },
+  "files": [
+    "src",
+    "dist"
+  ],
   "pre-commit": [
     "lint",
     "minify",


### PR DESCRIPTION
Removes tests, demos, build scripts, etc. from package manager distribution
to keep the overall file size down and improve installation speed.

- package.json: Only include files in 'src' and 'dist' in npm
- bower.json: Ignore all files except for 'src' and 'dist' for bower