### PR TITLE
Minor fix for URI scheme whitelist demo hook

### DIFF
--- a/demos/hooks-scheme-whitelist.html
+++ b/demos/hooks-scheme-whitelist.html
@@ -38,7 +38,7 @@
             var whitelist = ['http', 'https', 'ftp'];
 
             // build fitting regex
-            var regex = RegExp('^('+whitelist.join('|')+'):', 'gim');
+            var regex = RegExp('^('+whitelist.join('|')+'):', 'im');
 
             // Add a hook to enforce URI scheme whitelist
             DOMPurify.addHook('afterSanitizeAttributes', function(node){


### PR DESCRIPTION
We just caught an issue in @cyph that was causing links sent in succession to break as in the attached screenshot, and this turned out to be the culprit.

From the MDN docs on RegExp.test: "As with exec() (or in combination with it), test() called multiple times on the same global regular expression instance will advance past the previous match."

Test for comparison:

```
const regex0 = /^(http|https|ftp):/gim
const regex1 = /^(http|https|ftp):/im

regex0.test('https:')
true
regex0.test('https:')
false
regex0.test('https:')
true
regex0.test('https:')
false

regex1.test('https:')
true
regex1.test('https:')
true
regex1.test('https:')
true
regex1.test('https:')
true
```
<img width="131" alt="screen shot 2017-02-24 at 5 27 45 pm" src="https://cloud.githubusercontent.com/assets/415435/23326179/4adfb8fc-fac9-11e6-85f7-f7d49c129265.png">
