### PR TITLE
Option to set config once

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -234,7 +234,10 @@
     /* Decide if document with <html>... should be returned */
     var WHOLE_DOCUMENT = false;
 
-    /* Decide if all elements (e.g. style, script) must be children of 
+    /* Track whether config is already set on this instance of DOMPurify. */
+    var SET_CONFIG = false;
+
+    /* Decide if all elements (e.g. style, script) must be children of
      * document.body. By default, browsers might move them to document.head */
     var FORCE_BODY = false;
 
@@ -771,7 +774,9 @@
         }
 
         /* Assign config vars */
-        _parseConfig(cfg);
+        if (!SET_CONFIG) {
+            _parseConfig(cfg);
+        }
 
         /* Clean up removed elements */
         DOMPurify.removed = [];
@@ -860,6 +865,29 @@
         }
 
         return WHOLE_DOCUMENT ? body.outerHTML : body.innerHTML;
+    };
+
+    /**
+     * setConfig
+     * Public method to set the configuration once
+     *
+     * @param {Object} configuration object
+     * @return void
+     */
+    DOMPurify.setConfig = function(cfg) {
+        _parseConfig(cfg);
+        SET_CONFIG = true;
+    };
+
+    /**
+     * clearConfig
+     * Public method to remove the configuration
+     *
+     * @return void
+     */
+    DOMPurify.clearConfig = function() {
+        CONFIG = null;
+        SET_CONFIG = false;
     };
 
     /**


### PR DESCRIPTION
This proposal allows for the setting and clearing of the configuration the DOMPurify instance, similar to add/remove hooks.

Tests will be added if/when this feature solidifies. 