### PR TITLE
Fix broken test for useDOMParser

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -434,7 +434,7 @@
     if (DOMPurify.isSupported) {
         (function () {
             var doc = _initDocument('<svg><p><style><img src="</style><img src=x onerror=alert(1)//">');
-            if (doc.getElementsByTagName('img')[0].hasAttribute('onerror')) {
+            if (doc.querySelector('svg img')) {
                 useDOMParser = true;
             }
         }());


### PR DESCRIPTION
The logic was inverted, so this was broken in *both* the Safari and Firefox
edge cases.

This replaces it with a simpler test, which I have confirmed is right in both Safari and Firefox. One question though: why was this not picked up by the automated tests? The test suite should have failed in Safari 10.1 with 0.8.7, and I thought you had added this to the browser matrix?