### PR TITLE
Add running one BrowserStack integration test on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: node_js
 cache: yarn
-script: npm run test:ci
+script:
+   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then npm run test:ci:pr; fi'
+   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run test:ci; fi'
 notifications:
    email: false
 env:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:umd:min": "cross-env NODE_ENV=production BABEL_ENV=rollup rollup -c -o dist/purify.min.js",
     "test:jsdom": "cross-env NODE_ENV=test BABEL_ENV=rollup node test/jsdom-node-runner --dot",
     "test:karma": "cross-env NODE_ENV=test BABEL_ENV=rollup karma start test/karma.conf.js --log-level warn ",
-    "test:ci": "cross-env NODE_ENV=test BABEL_ENV=rollup npm run lint && npm run test:jsdom && (([ \"${TRAVIS_PULL_REQUEST}\" != \"false\" ] || [ \"${TEST_BROWSERSTACK}\" != \"true\" ]) || karma start test/karma.conf.js --log-level error --reporters dots --single-run)",
+    "test:ci": "cross-env NODE_ENV=test BABEL_ENV=rollup npm run lint && npm run test:jsdom && (([ \"${TEST_BROWSERSTACK}\" != \"true\" ]) || karma start test/karma.conf.js --log-level error --reporters dots --single-run)",
+    "test:ci:pr": "cross-env NODE_ENV=test BABEL_ENV=rollup npm run lint && npm run test:jsdom && (([ \"${TEST_BROWSERSTACK}\" != \"true\" ]) || karma start test/karma.conf.js --log-level error --reporters dots --single-run --browsers bs_win10_chrome_57)",
     "test": "cross-env NODE_ENV=test BABEL_ENV=rollup npm run lint && npm run test:jsdom && npm run test:karma -- --browsers Chrome"
   },
   "files": [


### PR DESCRIPTION
> This pull request implements running one integration test on BrowserStack for PRs.

### Background & Context

We only notice if real browser tests fail once PRs are merged. This happened to us on the rollup migration. This PR suggests a way to run the currently latest chrome for PRs.

We ran no BrowserStack CI before to save time from our plan but we have little PRs at the moment. Just trying this out might work.

1. Helps identify potential config problems for karma before merging
2. Makes sure things work in a real browser in a PR

⚠️ Just a suggestion, please don't merge yet ⚠️ 
