### PR TITLE
Whitelist preserveAspectRatio

### DIFF
--- a/src/attrs.js
+++ b/src/attrs.js
@@ -201,6 +201,7 @@ export const svg = [
   'patternunits',
   'points',
   'preservealpha',
+  'preserveaspectratio',
   'r',
   'rx',
   'ry',


### PR DESCRIPTION
> This pull request whitelists preserveAspectRatio

### Background & Context

I want to use preserveAspectRatio with my SVGs to control scaling. This should be a straightforward change. MDN in case anyone's curious: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio

### Tasks

- Nothing?

### Dependencies

None?
