### PR TITLE
Add support for 'use' tag with SVGs

### DIFF
--- a/src/tags.js
+++ b/src/tags.js
@@ -161,6 +161,7 @@ export const svg = [
   'title',
   'tref',
   'tspan',
+  'use',
   'video',
   'view',
   'vkern',


### PR DESCRIPTION
> This pull request [implements, fixes, changes]...

Allow usage of the `use` tag in SVG.

### Background & Context

Unsure if there's a criteria for what is included or not, please let me know if there's a reason this can't be added.

https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use

### Tasks

na

### Dependencies

na