### PR TITLE
Change npm publish to "dist" only

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,7 @@
   "module": "dist/purify.es.js",
   "browser": "dist/purify.js",
   "files": [
-    "dist",
-    "package.json",
-    "yarn.lock",
-    "package-lock.json",
-    "README.md"
+    "dist"
   ],
   "pre-commit": [
     "lint",


### PR DESCRIPTION
> This pull request changes `package.json` so that npm publish only publishes the dist folder plus the default file such as README.md

### Background & Context

npm is pretty smart and already figures out which files are necessary and which ones are not https://docs.npmjs.com/files/package-lock.json

You can see how dompurify used to avoid publishing these files and has since grown in size: https://packagephobia.now.sh/result?p=dompurify

### Tasks

- Add tasks to give a quick overview for QA and reviewers

### Dependencies

If there are any dependencies on PRs or API work then list them here.

- [x] Resolved dependency
- [ ] Open dependency
