### PR TITLE
sanitize input[type=file] if hookEvent.keepAttr is false

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -845,6 +845,7 @@ function createDOMPurify(window = getGlobal()) {
         currentNode.nodeName === 'INPUT' &&
         lcName === 'type' &&
         value === 'file' &&
+        hookEvent.keepAttr &&
         (ALLOWED_ATTR[lcName] || !FORBID_ATTR[lcName])
       ) {
         continue;

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -310,6 +310,21 @@ module.exports = function(DOMPurify, window, tests, xssTests) {
       DOMPurify.removeHooks('uponSanitizeElement');
       DOMPurify.removeHooks('uponSanitizeAttribute');
   } );
+  // Test to ensure that if input[type=file] is blacklisted and flagged as an
+  // attribute not to keep via hookEvent.keepAttr, it should be removed despite
+  // it being an issue of being able to programmatically add it back in Safari.
+  QUnit.test( 'ensure that input[type=file] is removed via hookEvent keepAttr', function(assert) {
+      DOMPurify.addHook('uponSanitizeAttribute', function(node, data){
+        if(node.nodeName == 'INPUT' && node.getAttribute('type')
+          && node.getAttribute('type') == 'file') {
+            data.keepAttr = false;
+        }
+      });
+      var dirty = '<input type="file" />';
+      var modified = '<input>';
+      assert.equal(DOMPurify.sanitize(dirty), modified);
+      DOMPurify.removeHooks('uponSanitizeAttribute');
+  } );
   QUnit.test( 'sanitize() should allow unknown protocols when ALLOW_UNKNOWN_PROTOCOLS is true', function (assert) {
       var dirty = '<div><a href="spotify:track:12345"><img src="cid:1234567"></a></div>';
       assert.equal(dirty, DOMPurify.sanitize(dirty, {ALLOW_UNKNOWN_PROTOCOLS: true}));


### PR DESCRIPTION
This pull request allows for the sanitization/blacklisting of `<input type="file" />` by setting the hookEvent keepAttr to false.

### Background & Context

Currently an [AMP HTML](https://github.com/ampproject/amphtml)  spec disallows for the following usage in templates: input[type=file]
DOM Purify does not allow for the sanitization of the type `file` because of a Safari bug which doesn't permit the adding back of this attribute once removed. See https://github.com/cure53/DOMPurify/blob/master/src/purify.js#L843

