### PR TITLE
Fix sanitize() issue on Chrome 77

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -1098,7 +1098,7 @@ function createDOMPurify(window = getGlobal()) {
     }
 
     return trustedTypesPolicy
-      ? trustedTypesPolicy.createHTML(serializedHTML)
+      ? trustedTypesPolicy.createHTML(serializedHTML).toString()
       : serializedHTML;
   };
 


### PR DESCRIPTION
See : https://github.com/cure53/DOMPurify/issues/361

> This pull request [fixes]

### Background & Context

https://github.com/cure53/DOMPurify/issues/361

### Tasks

- Call `.toString()` of `TrustedHTML-Object`

