### PR TITLE
:white_check_mark: test case for #372

### DIFF
--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -520,6 +520,7 @@ module.exports = function(DOMPurify, window, tests, xssTests) {
           '<svg keep="me"></svg>', 
           "<svg xmlns=\"http://www.w3.org/2000/svg\" keep=\"me\" />"
       ] );
+      assert.equal( DOMPurify.sanitize( ' ', {USE_PROFILES: {html: true}} ), '' );
   });
   QUnit.test( 'Config-Flag tests: ALLOWED_URI_REGEXP', function(assert) {
       var tests = [


### PR DESCRIPTION
Add test case for sanitizing white space character returning empty
string. This bounds the behaviour with test case.

See: #372