### PR TITLE
docs(readme): adjust invalid sanitize example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ How does purified markup look like? Well, [the demo](https://cure53.de/purify) s
 ```javascript
 DOMPurify.sanitize('<img src=x onerror=alert(1)//>'); // becomes <img src="x">
 DOMPurify.sanitize('<svg><g/onload=alert(2)//<p>'); // becomes <svg><g></g></svg>
-DOMPurify.sanitize('<p>abc<iframe//src=jAva&Tab;script:alert(3)>def'); // becomes <p>abcdef</p>
+DOMPurify.sanitize('<p>abc<iframe//src=jAva&Tab;script:alert(3)>def</p>'); // becomes <p>abcdef</p>
 DOMPurify.sanitize('<math><mi//xlink:href="data:x,<script>alert(4)</script>">'); // becomes <math><mi></mi></math>
 DOMPurify.sanitize('<TABLE><tr><td>HELLO</tr></TABL>'); // becomes <table><tbody><tr><td>HELLO</td></tr></tbody></table>
 DOMPurify.sanitize('<UL><li><A HREF=//google.com>click</UL>'); // becomes <ul><li><a href="//google.com">click</a></li></ul>


### PR DESCRIPTION
> This pull request adjust a invalid sanitize example in the readme

### Background & Context
The example has a missing closing `</p>` tag
