### PR TITLE
add startOffset to svg allowed attrs

### DIFF
--- a/src/attrs.js
+++ b/src/attrs.js
@@ -225,6 +225,7 @@ export const svg = freeze([
   'specularconstant',
   'specularexponent',
   'spreadmethod',
+  'startoffset',
   'stddeviation',
   'stitchtiles',
   'stop-color',


### PR DESCRIPTION
This pull request adds [`startOffset`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/startOffset) to the list of allowed SVG attributes.

### Background & Context

When using DOMPurify to sanitize SVGs that include the `startOffset` attribute, the sanitize process removes the `startOffset` attribute, causing a visual breakage. The [MDN docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/startOffset) provide a good example that illustrates the visual difference when `startAttribute` is applied vs not applied:

<img width="454" alt="Screen Shot 2020-03-14 at 6 33 41 PM" src="https://user-images.githubusercontent.com/8152930/76691612-dcf22780-6622-11ea-93d4-fec8fe817617.png">

There are no known security concerns associated with this attribute, and other major open source libraries include it in their safelists (including [React](https://github.com/facebook/react/blob/8cb2fb21eb4e931b80d8b0502059061891ac4563/packages/react-dom/src/shared/possibleStandardNames.js#L374), [JSanity](https://github.com/microsoft/JSanity/blob/ad31336085c2565891e0a882444a99450e060881/jsanity-0.3.js#L595), and [Loofah](https://github.com/flavorjones/loofah/blob/0eb99761d1d86309f403a767d6254c05e1bea42b/lib/loofah/html5/safelist.rb#L451)).

This patch adds the attribute to the safelist in order to allow sanitized SVGs with `startOffset` to render as expected.

### Tasks

N/A

### Dependencies

None.
