### PR TITLE
fix: argv parsing with github actions

### DIFF
--- a/test/karma.custom-launchers.config.js
+++ b/test/karma.custom-launchers.config.js
@@ -223,8 +223,8 @@ const getRandomBrowser = () => sample(getAllBrowsers());
  * - If none of the prior mentioned holds we assume to be running local and respect the passed
  *   in borwsers argv
  */
-const shouldProbeOnly = argv.shouldProbeOnly !== 'false';
-const shouldTestOnBrowserStack = argv.shouldTestOnBrowserStack !== '';
+const shouldProbeOnly = argv.shouldProbeOnly === 'true';
+const shouldTestOnBrowserStack = argv.shouldTestOnBrowserStack === 'true';
 const defaultBrowsers = ['Firefox'];
 const argvBrowsers = isArray(argv.browsers)
   ? argv.browsers.split(' ')


### PR DESCRIPTION
### Background & Context

With GitHub Actions these args are not always set cause we evaluate them as expressions in the workflow file. On TravisCI we hoped that an env variable would be set. That simplifies things here and allows it to be more explicit.

I noticed cause we currently run both Node.js v13 and v12 in the matrix against BrowserStack which is not needed cause we evaluated for anything but an empty string to trigger it :)