### PR TITLE
fix: add @license to comment

### DIFF
--- a/src/license_header
+++ b/src/license_header
@@ -1,1 +1,1 @@
-/*! DOMPurify | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/2.0.8/LICENSE */
+/*! @license DOMPurify | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/2.0.8/LICENSE */


### PR DESCRIPTION
This `@license` is what Google Closure Compiler and hence terser uses to preserve the comment. There is also a `@preseve` but this feels more meaningful. 