### PR TITLE
Move node and nvm to the dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     ]
   },
   "devDependencies": {
+    "@babel/plugin-external-helpers": "7.8.3",
     "babel": "^6.23.0",
     "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",
-    "@babel/plugin-external-helpers": "7.8.3",
     "cross-env": "^7.0.2",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.3",
@@ -82,7 +82,9 @@
     "lodash.isarray": "^4.0.0",
     "lodash.sample": "^4.2.1",
     "minimist": "^1.2.5",
+    "node": "^13.13.0",
     "npm-run-all": "^4.1.5",
+    "nvm": "0.0.4",
     "pre-commit": "^1.1.2",
     "prettier": "^2.0.4",
     "qunit-parameterize": "^0.4.0",
@@ -131,8 +133,5 @@
     "url": "https://github.com/cure53/DOMPurify/issues"
   },
   "homepage": "https://github.com/cure53/DOMPurify",
-  "dependencies": {
-    "node": "^13.13.0",
-    "nvm": "0.0.4"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
### Background & Context

Closes #427.

node and nvm are not used at runtime by DOMPurify.
They initially have been introduced by c9661e1a4c2e32b0ad87807b12eb33edc1361095 which looks like a painful debugging session
