### PR TITLE
fix: license header not being added

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const env = process.env.NODE_ENV;
 const isProd = env === 'production';
 const version = process.env.npm_package_version;
+const license = fs.readFileSync('./src/license_header', 'utf8');
 
 const config = {
   input: 'src/purify.js',
@@ -16,7 +17,7 @@ const config = {
     globals: {},
     format: 'umd',
     sourcemap: true,
-    banner: fs.readFileSync('./src/license_header'),
+    banner: license,
   },
   plugins: [
     nodeResolve(),


### PR DESCRIPTION
> This pull request fixes the license header to be added.

### Background & Context

The license header's file content was read into a buffer:

<img width="1206" alt="CleanShot 2020-04-23 at 09 13 45@2x" src="https://user-images.githubusercontent.com/1877073/80070241-f43a0400-8542-11ea-98cb-25dc5f6f67dc.png">

Rollup doesn't prepend buffers if specified as the banner. We now read the license as utf-8. This adds it to the dist files.