### PR TITLE
Fix lack of RETURN_TRUSTED_TYPE check

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -127,7 +127,7 @@ function createDOMPurify(window = getGlobal()) {
     trustedTypes,
     originalDocument
   );
-  const emptyHTML = trustedTypesPolicy ? trustedTypesPolicy.createHTML('') : '';
+  const emptyHTML = trustedTypesPolicy && RETURN_TRUSTED_TYPE ? trustedTypesPolicy.createHTML('') : '';
 
   const {
     implementation,
@@ -1085,7 +1085,7 @@ function createDOMPurify(window = getGlobal()) {
         // eslint-disable-next-line unicorn/prefer-includes
         dirty.indexOf('<') === -1
       ) {
-        return trustedTypesPolicy
+        return trustedTypesPolicy && RETURN_TRUSTED_TYPE
           ? trustedTypesPolicy.createHTML(dirty)
           : dirty;
       }


### PR DESCRIPTION
Some code returns a `trustedHTML` value without confirming `RETURN_TRUSTED_TYPE`. This PR is for adding the check.