### PR TITLE
Fix advanced config demo

### DIFF
--- a/demos/advanced-config-demo.html
+++ b/demos/advanced-config-demo.html
@@ -31,8 +31,8 @@
             // Clean HTML string and write into our DIV
             var clean = DOMPurify.sanitize(dirty, config);
 
-            // grab outerHTML from returned document
-            document.getElementById('sanitized').innerHTML = clean;
+            // Grab innerHTML from returned clean body node
+            document.getElementById('sanitized').innerHTML = clean.innerHTML;
         </script>
     </body>
 </html>


### PR DESCRIPTION
The advanced config demo incorrectly assigned `innerHTML` from a DOM node
instead of a string.
