### PR TITLE
docs: Fix simple typo, retrun -> return

### DIFF
--- a/dist/purify.cjs.js
+++ b/dist/purify.cjs.js
@@ -346,7 +346,7 @@ function createDOMPurify() {
    * DOMPurify. */
   var RETURN_DOM_IMPORT = false;
 
-  /* Try to return a Trusted Type object instead of a string, retrun a string in
+  /* Try to return a Trusted Type object instead of a string, return a string in
    * case Trusted Types are not supported  */
   var RETURN_TRUSTED_TYPE = false;
 

--- a/dist/purify.js
+++ b/dist/purify.js
@@ -350,7 +350,7 @@
      * DOMPurify. */
     var RETURN_DOM_IMPORT = false;
 
-    /* Try to return a Trusted Type object instead of a string, retrun a string in
+    /* Try to return a Trusted Type object instead of a string, return a string in
      * case Trusted Types are not supported  */
     var RETURN_TRUSTED_TYPE = false;
 

--- a/src/purify.js
+++ b/src/purify.js
@@ -238,7 +238,7 @@ function createDOMPurify(window = getGlobal()) {
    * DOMPurify. */
   let RETURN_DOM_IMPORT = false;
 
-  /* Try to return a Trusted Type object instead of a string, retrun a string in
+  /* Try to return a Trusted Type object instead of a string, return a string in
    * case Trusted Types are not supported  */
   let RETURN_TRUSTED_TYPE = false;
 


### PR DESCRIPTION
There is a small typo in dist/purify.cjs.js, dist/purify.js, src/purify.js.

Should read `return` rather than `retrun`.

