### PR TITLE
Update license Header to match current Version

### DIFF
--- a/src/license_header
+++ b/src/license_header
@@ -1,1 +1,1 @@
-/*! @license DOMPurify | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/2.0.8/LICENSE */
+/*! @license DOMPurify | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/2.2.2/LICENSE */


### PR DESCRIPTION
Update The header to match the current version of the npm package 
Firefox rejected an update to an extension on their store saying the version is not updated and has security issues, but is the updated version, just with bad header

> This pull request [implements, fixes, changes]...
Changes
### Background & Context

The version number on the license header is old, resulting on mismatch for some requirements even if the code is the latest code.
For example when using just the DIST version inside a browser extension, the review team (firefox for example) checks there for the version and they need it to be up to date

### Tasks

- Add tasks to give a quick overview for QA and reviewers

### Dependencies

No dependencies 

- [x] Resolved dependency
- [ ] Open dependency
