### PR TITLE
Fixed playground syntax error

### DIFF
--- a/test/fixtures/expect.js
+++ b/test/fixtures/expect.js
@@ -1031,7 +1031,7 @@ module.exports = [
           "",
           "<math></math><p></p><textarea>&lt;mi&gt;&lt;style&gt;</textarea><img src=\"x\">",
           "<math></math><p></p><img src=\"x\">",
-          "<math></math>",
+          "<math></math>"
       ]
   }, {
       "title": "Tests against mXSS behavior with SVG Templates in Chrome 77 and alike",
@@ -1051,7 +1051,7 @@ module.exports = [
           "",
           "<math></math>",
           "<math></math><br><textarea>&lt;mtext&gt;&lt;template&gt;&lt;style&gt;</textarea><img src=\"x\">",
-          "<math></math><br><img src=\"x\">",
+          "<math></math><br><img src=\"x\">"
       ]
   }, {
       "title": "Fixed an exception coming from missing clobbering protection",


### PR DESCRIPTION
> This pull request is a quick to the playground at https://cure53.de/purify

### Background & Context

The playground currently raises a syntax error due to the training comma in the test JS file that is converted to JSON.
