### PR TITLE
add fallback for lookup-getter util

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -833,12 +833,18 @@ function createDOMPurify(window = getGlobal()) {
       if (KEEP_CONTENT && !FORBID_CONTENTS[tagName]) {
         const parentNode = getParentNode(currentNode);
         const childNodes = getChildNodes(currentNode);
-        const childCount = childNodes.length;
-        for (let i = childCount - 1; i >= 0; --i) {
-          parentNode.insertBefore(
-            cloneNode(childNodes[i], true),
-            getNextSibling(currentNode)
-          );
+
+        if (childNodes) {
+          const childCount = childNodes.length;
+
+          for (let i = childCount - 1; i >= 0; --i) {
+            if (parentNode) {
+              parentNode.insertBefore(
+                cloneNode(childNodes[i], true),
+                getNextSibling(currentNode)
+              );
+            }
+          }
         }
       }
 

--- a/src/purify.js
+++ b/src/purify.js
@@ -834,16 +834,14 @@ function createDOMPurify(window = getGlobal()) {
         const parentNode = getParentNode(currentNode);
         const childNodes = getChildNodes(currentNode);
 
-        if (childNodes) {
+        if (childNodes && parentNode) {
           const childCount = childNodes.length;
 
           for (let i = childCount - 1; i >= 0; --i) {
-            if (parentNode) {
-              parentNode.insertBefore(
-                cloneNode(childNodes[i], true),
-                getNextSibling(currentNode)
-              );
-            }
+            parentNode.insertBefore(
+              cloneNode(childNodes[i], true),
+              getNextSibling(currentNode)
+            );
           }
         }
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -122,6 +122,7 @@ function lookupGetter(object, prop) {
   }
 
   function fallbackValue(element) {
+    console.warn('fallback value for', element);
     return null;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -121,7 +121,11 @@ function lookupGetter(object, prop) {
     object = getPrototypeOf(object);
   }
 
-  return null;
+  function fallbackValue(element) {
+    return null;
+  }
+
+  return fallbackValue;
 }
 
 export {


### PR DESCRIPTION
> This pull request fixes an issue for lookupGetter utility.

### Background & Context

When there is no entries for properties, it returns null. Instead as a fallback the utility could return a function, which could be used i.e. to get nullable parent node.
