### PR TITLE
Adding missing `slot` attribute

### DIFF
--- a/src/attrs.js
+++ b/src/attrs.js
@@ -108,6 +108,7 @@ export const html = freeze([
   'value',
   'width',
   'xmlns',
+  'slot'
 ]);
 
 export const svg = freeze([

--- a/src/attrs.js
+++ b/src/attrs.js
@@ -108,7 +108,7 @@ export const html = freeze([
   'value',
   'width',
   'xmlns',
-  'slot'
+  'slot',
 ]);
 
 export const svg = freeze([


### PR DESCRIPTION
### Background & Context

Currently content within custom elements will have their `slot` attribute removed. This attribute is standard HTML and should not be stripped. This pull request adds the `slot` attribute to the safe list.

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/slot