### PR TITLE
Expose `FORBID_CONTENTS` to allow users to specify which elements DOMPurify should remove from the input with its children

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -451,7 +451,7 @@ function createDOMPurify(window = getGlobal()) {
     if (cfg.ADD_URI_SAFE_ATTR) {
       addToSet(URI_SAFE_ATTRIBUTES, cfg.ADD_URI_SAFE_ATTR);
     }
-    
+
     if (cfg.FORBID_CONTENTS) {
       if (FORBID_CONTENTS === DEFAULT_FORBID_CONTENTS) {
         FORBID_CONTENTS = clone(FORBID_CONTENTS);

--- a/src/purify.js
+++ b/src/purify.js
@@ -263,7 +263,8 @@ function createDOMPurify(window = getGlobal()) {
   let USE_PROFILES = {};
 
   /* Tags to ignore content of when KEEP_CONTENT is true */
-  const FORBID_CONTENTS = addToSet({}, [
+  let FORBID_CONTENTS = null;
+  const DEFAULT_FORBID_CONTENTS = addToSet({}, [
     'annotation-xml',
     'audio',
     'colgroup',
@@ -372,6 +373,10 @@ function createDOMPurify(window = getGlobal()) {
       'ADD_DATA_URI_TAGS' in cfg
         ? addToSet(clone(DEFAULT_DATA_URI_TAGS), cfg.ADD_DATA_URI_TAGS)
         : DEFAULT_DATA_URI_TAGS;
+    FORBID_CONTENTS =
+      'FORBID_CONTENTS' in cfg
+        ? addToSet({}, cfg.FORBID_CONTENTS)
+        : DEFAULT_FORBID_CONTENTS;
     FORBID_TAGS = 'FORBID_TAGS' in cfg ? addToSet({}, cfg.FORBID_TAGS) : {};
     FORBID_ATTR = 'FORBID_ATTR' in cfg ? addToSet({}, cfg.FORBID_ATTR) : {};
     USE_PROFILES = 'USE_PROFILES' in cfg ? cfg.USE_PROFILES : false;
@@ -445,6 +450,14 @@ function createDOMPurify(window = getGlobal()) {
 
     if (cfg.ADD_URI_SAFE_ATTR) {
       addToSet(URI_SAFE_ATTRIBUTES, cfg.ADD_URI_SAFE_ATTR);
+    }
+    
+    if (cfg.FORBID_CONTENTS) {
+      if (FORBID_CONTENTS === DEFAULT_FORBID_CONTENTS) {
+        FORBID_CONTENTS = clone(FORBID_CONTENTS);
+      }
+
+      addToSet(FORBID_CONTENTS, cfg.FORBID_CONTENTS);
     }
 
     /* Add #text in case KEEP_CONTENT is set to true */

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -161,6 +161,19 @@ module.exports = function (DOMPurify, window, tests, xssTests) {
       '<my-component my-attr="foo">abc</my-component>'
     );
   });
+  QUnit.test(
+    'Config-Flag tests: FORBID_CONTENTS + FORBID_TAGS',
+    function (assert) {
+      // FORBID_CONTENTS + FORBID_TAGS
+      assert.equal(
+        DOMPurify.sanitize(
+          '<div><b>preserve me</b></div><p><b>no not preserve me</b></p>',
+          { FORBID_CONTENTS: ['p'], FORBID_TAGS: ['div', 'p'] }
+        ),
+        '<b>preserve me</b>'
+      );
+    }
+  );
   QUnit.test('Config-Flag tests: SAFE_FOR_JQUERY (now inactive, secure by default)', function (assert) {
     assert.equal(
       DOMPurify.sanitize('<a>123</a><option><style><img src=x onerror=alert(1)>'),


### PR DESCRIPTION
> This pull request [implements, fixes, changes]...

### Background & Context

https://github.com/cure53/DOMPurify/issues/556


### Dependencies

If there are any dependencies on PRs or API work then list them here.

- [x] Resolved dependency
- [ ] Open dependency
