### PR TITLE
Fix README.md to reference application/xhtml+xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ var clean = DOMPurify.sanitize(dirty, {KEEP_CONTENT: false});
 var clean = DOMPurify.sanitize(dirty, {FORCE_BODY: true});
 
 // change the parser type so sanitized data is treated as XML and not as HTML, which is the default
-var clean = DOMPurify.sanitize(dirty, {PARSER_MEDIA_TYPE: 'application/xml'});
+var clean = DOMPurify.sanitize(dirty, {PARSER_MEDIA_TYPE: 'application/xhtml+xml'});
 
 /**
  * Influence where we sanitize


### PR DESCRIPTION
> This pull request fixes README.md for `PARSER_MEDIA_TYPE`

### Background & Context

https://github.com/cure53/DOMPurify/pull/568 introduces XML parsing by specifying application/xhtml+xml as `PARSER_MEDIA_TYPE`. Any other type is parsed as text/html, if I understand correctly. The README.md said to use application/xml for XML parsing, which is thus incorrect.

### Tasks

none

### Dependencies

none
