### PR TITLE
chore: updated comments to use main instead of master

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 # The event triggers are configured as following:
-# - on `master` -> trigger the workflow on every push
+# - on `main` -> trigger the workflow on every push
 # - on any pull request -> trigger the workflow
 # This is to avoid running the workflow twice on pull requests.
 on:


### PR DESCRIPTION
updated comments to use `main` instead of `master`

### Background & Context

This project's default branch is `main`.
