### PR TITLE
chore: remove deprecated lodash.isarray

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "karma-json-fixtures-preprocessor": "0.0.6",
         "karma-qunit": "^1.0.0",
         "karma-rollup-preprocessor": "^5.0.2",
-        "lodash.isarray": "^4.0.0",
         "lodash.sample": "^4.2.1",
         "minimist": "^1.2.5",
         "npm-run-all": "^4.1.5",
@@ -7721,13 +7720,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
-    "node_modules/lodash.isarray": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
-      "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM=",
-      "deprecated": "This package is deprecated. Use Array.isArray.",
       "dev": true
     },
     "node_modules/lodash.sample": {
@@ -20058,12 +20050,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
-      "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM=",
       "dev": true
     },
     "lodash.sample": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "karma-json-fixtures-preprocessor": "0.0.6",
     "karma-qunit": "^1.0.0",
     "karma-rollup-preprocessor": "^5.0.2",
-    "lodash.isarray": "^4.0.0",
     "lodash.sample": "^4.2.1",
     "minimist": "^1.2.5",
     "npm-run-all": "^4.1.5",

--- a/test/karma.custom-launchers.config.js
+++ b/test/karma.custom-launchers.config.js
@@ -1,6 +1,5 @@
 const sample = require('lodash.sample');
 const argv = require('minimist')(process.argv.slice(2));
-const isArray = require('lodash.isarray');
 
 const customLaunchers = {
   bs_sierra_safari_10: {
@@ -171,7 +170,7 @@ const getRandomBrowser = () => sample(getAllBrowsers());
 const shouldProbeOnly = argv.shouldProbeOnly === 'true';
 const shouldTestOnBrowserStack = argv.shouldTestOnBrowserStack === 'true';
 const defaultBrowsers = ['Firefox'];
-const argvBrowsers = isArray(argv.browsers)
+const argvBrowsers = Array.isArray(argv.browsers)
   ? argv.browsers.split(' ')
   : defaultBrowsers;
 const browsers = shouldTestOnBrowserStack


### PR DESCRIPTION
This PR removes deprecated package `llodash.isarray`.

### Background & Context

https://www.npmjs.com/package/lodash.isarray
> This package is deprecated. Use Array.isArray.

https://caniuse.com/?search=isarray