### PR TITLE
Allow `transform-origin` attribute in SVGs

### DIFF
--- a/src/attrs.js
+++ b/src/attrs.js
@@ -264,6 +264,7 @@ export const svg = freeze([
   'targetx',
   'targety',
   'transform',
+  'transform-origin',
   'text-anchor',
   'text-decoration',
   'text-rendering',


### PR DESCRIPTION
> This pull request adds the `transform_origin` to the list of allowed attributes in the SVG filter. 

### Background & Context

This attribute is used to assign an origin about which to transform objects in an SVG. It's analogous to the `transform` attribute, which is currently allowlisted. 

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform-origin

### Tasks

- If this attribute introduces a XSS risk, or requires further discussion, I can turn this PR into a draft and file an issue instead :)

### Dependencies
