### PR TITLE
chore: remove deprecated package babel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "devDependencies": {
         "@babel/plugin-external-helpers": "7.12.13",
-        "babel": "^6.23.0",
         "babel-core": "^6.26.3",
         "babel-preset-env": "^1.7.0",
         "cross-env": "^7.0.3",
@@ -1452,18 +1451,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
-    },
-    "node_modules/babel": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-6.23.0.tgz",
-      "integrity": "sha1-0NHn2APpdHZb7qMjLU4VPA77kPQ=",
-      "deprecated": "In 6.x, the babel package has been deprecated in favor of babel-cli. Check https://opencollective.com/babel to support the Babel maintainers",
-      "dev": true,
-      "bin": {
-        "babel": "lib/cli.js",
-        "babel-external-helpers": "lib/cli.js",
-        "babel-node": "lib/cli.js"
-      }
     },
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
@@ -14374,12 +14361,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
-    },
-    "babel": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-6.23.0.tgz",
-      "integrity": "sha1-0NHn2APpdHZb7qMjLU4VPA77kPQ=",
       "dev": true
     },
     "babel-code-frame": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@babel/plugin-external-helpers": "7.12.13",
-    "babel": "^6.23.0",
     "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
This PR removes deprecated package `babel`.

### Background & Context

The package has been deprecated.

https://www.npmjs.com/package/babel
> In 6.x, the babel package has been deprecated in favor of babel-cli. Check https://opencollective.com/babel to support the Babel maintainers

Also, it seems this project doesn't depend on the package so I guess we can remove it simply. 
