### PR TITLE
chore: bump karma-firefox-launcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "karma": "^5.1.0",
         "karma-browserstack-launcher": "^1.5.1",
         "karma-chrome-launcher": "^3.1.0",
-        "karma-firefox-launcher": "^1.3.0",
+        "karma-firefox-launcher": "^2.1.2",
         "karma-fixture": "^0.2.6",
         "karma-html2js-preprocessor": "^1.0.0",
         "karma-json-fixtures-preprocessor": "0.0.6",
@@ -7341,12 +7341,13 @@
       }
     },
     "node_modules/karma-firefox-launcher": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.3.0.tgz",
-      "integrity": "sha512-Fi7xPhwrRgr+94BnHX0F5dCl1miIW4RHnzjIGxF8GaIEp7rNqX7LSi7ok63VXs3PS/5MQaQMhGxw+bvD+pibBQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-2.1.2.tgz",
+      "integrity": "sha512-VV9xDQU1QIboTrjtGVD4NCfzIH7n01ZXqy/qpBhnOeGVOkG5JYPEm8kuSd7psHE6WouZaQ9Ool92g8LFweSNMA==",
       "dev": true,
       "dependencies": {
-        "is-wsl": "^2.1.0"
+        "is-wsl": "^2.2.0",
+        "which": "^2.0.1"
       }
     },
     "node_modules/karma-fixture": {
@@ -19105,12 +19106,13 @@
       }
     },
     "karma-firefox-launcher": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.3.0.tgz",
-      "integrity": "sha512-Fi7xPhwrRgr+94BnHX0F5dCl1miIW4RHnzjIGxF8GaIEp7rNqX7LSi7ok63VXs3PS/5MQaQMhGxw+bvD+pibBQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-2.1.2.tgz",
+      "integrity": "sha512-VV9xDQU1QIboTrjtGVD4NCfzIH7n01ZXqy/qpBhnOeGVOkG5JYPEm8kuSd7psHE6WouZaQ9Ool92g8LFweSNMA==",
       "dev": true,
       "requires": {
-        "is-wsl": "^2.1.0"
+        "is-wsl": "^2.2.0",
+        "which": "^2.0.1"
       }
     },
     "karma-fixture": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "karma": "^5.1.0",
     "karma-browserstack-launcher": "^1.5.1",
     "karma-chrome-launcher": "^3.1.0",
-    "karma-firefox-launcher": "^1.3.0",
+    "karma-firefox-launcher": "^2.1.2",
     "karma-fixture": "^0.2.6",
     "karma-html2js-preprocessor": "^1.0.0",
     "karma-json-fixtures-preprocessor": "0.0.6",


### PR DESCRIPTION
This PR updates `karma-firefox-launcher` to the latest version.

### Background & Context

https://github.com/karma-runner/karma-firefox-launcher/blob/master/CHANGELOG.md
> Changed minimum required version of node.js from 8 to 10.

This project's CI does not cover Node.js 8, so I don't think the breaking change will affect it.
