### PR TITLE
chore: fix import path for testing

### DIFF
--- a/test/purify.spec.js
+++ b/test/purify.spec.js
@@ -1,4 +1,4 @@
-import DOMPurify from 'purify.min';
+import DOMPurify from 'purify';
 import testSuite from './test-suite';
 import tests from './fixtures/expect';
 


### PR DESCRIPTION
This PR fixes importing path for `purify`

### Background & Context

I found [this PR](https://github.com/cure53/DOMPurify/commit/991491212e5e88b446058609d68f3b3205e3a9d9#diff-bbbda76b86d3bdd2a249ec0e11c054d82317e1d752fc13343a934802e21c2e28) changed both `purify.spec.js` and `purify.min.spec.js` to import `purify.min`.

But `purify.spec.js` should test `purify`, not `purify.min`. 
