### PR TITLE
chore: fix test on IE11

### DIFF
--- a/test/config/setup.js
+++ b/test/config/setup.js
@@ -7,10 +7,10 @@ QUnit.assert.contains = function (actual, expected, message) {
   // Ref: https://api.qunitjs.com/assert/pushResult/
   this.pushResult(
     {
-      result,
-      actual,
-      expected,
-      message
+      result: result,
+      actual: actual,
+      expected: expected,
+      message: message
     }
   );
 };

--- a/test/jsdom-node.js
+++ b/test/jsdom-node.js
@@ -22,10 +22,10 @@ QUnit.assert.contains = function (actual, expected, message) {
   const result = expected.indexOf(actual) > -1;
   // Ref: https://api.qunitjs.com/assert/pushResult/
   this.pushResult({
-    result,
-    actual,
-    expected,
-    message,
+    result: result,
+    actual: actual,
+    expected: expected,
+    message: message,
   });
 };
 


### PR DESCRIPTION
This PR fixes CI failure on IE11.

### Background & Context

https://github.com/cure53/DOMPurify/runs/5175145927?check_suite_focus=true
> IE 11.0 (Windows 8.1) ERROR
>  Expected ':'
>  at test/config/setup.js:10:13
