### PR TITLE
chore: use unused variable

### DIFF
--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -1355,7 +1355,8 @@ module.exports = function (
         test: '<a href="mailto:demo@example.com">demo</a>',
         expected: '<a>demo</a>',
       },
-    ].forEach(function (test) {
+    ];
+    tests.forEach(function (test) {
       var str = DOMPurify.sanitize(test.test, {
         ALLOWED_URI_REGEXP:
           /^(?:(?:(?:f|ht)tps?):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,


### PR DESCRIPTION
This PR changes to use an unused `tests` variable correctly.

### Background & Context

In the unit tests, `tests` variable is declared but it is unused since `forEach` method is chained directly.
