### PR TITLE
chore: fix link to bug bounty info

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Of course there is a demo! [Play with DOMPurify](https://cure53.de/purify)
 
 First of all, please immediately contact us via [email](mailto:mario@cure53.de) so we can work on a fix. [PGP key](https://keyserver.ubuntu.com/pks/lookup?op=vindex&search=0xC26C858090F70ADA)
 
-Also, you probably qualify for a bug bounty! The fine folks over at [Fastmail](https://www.fastmail.com/) use DOMPurify for their services and added our library to their bug bounty scope. So, if you find a way to bypass or weaken DOMPurify, please also have a look at their website and the [bug bounty info](https://www.fastmail.com/about/bugbounty.html).
+Also, you probably qualify for a bug bounty! The fine folks over at [Fastmail](https://www.fastmail.com/) use DOMPurify for their services and added our library to their bug bounty scope. So, if you find a way to bypass or weaken DOMPurify, please also have a look at their website and the [bug bounty info](https://www.fastmail.com/about/bugbounty/).
 
 ## Some purification samples please?
 


### PR DESCRIPTION
This PR updated the link to the bug bounty info.

### Background & Context

The page is now redirected to https://www.fastmail.com/about/bugbounty/
