### PR TITLE
chore: update the link to bug bounty page

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@ Always the latest release.
 
 First of all, please immediately contact us via [email](mailto:mario@cure53.de) so we can work on a fix. [PGP key](https://keyserver.ubuntu.com/pks/lookup?op=vindex&search=0xC26C858090F70ADA)
 
-Also, you probably qualify for a bug bounty! The fine folks over at [Fastmail](https://www.fastmail.com/) use DOMPurify for their services and added our library to their bug bounty scope. So, if you find a way to bypass or weaken DOMPurify, please also have a look at their website and the [bug bounty info](https://www.fastmail.com/about/bugbounty.html).
+Also, you probably qualify for a bug bounty! The fine folks over at [Fastmail](https://www.fastmail.com/) use DOMPurify for their services and added our library to their bug bounty scope. So, if you find a way to bypass or weaken DOMPurify, please also have a look at their website and the [bug bounty info](https://www.fastmail.com/about/bugbounty/).


### PR DESCRIPTION
This PR updates the link to the bug bounty page. 

### Background & Context

https://www.fastmail.com/about/bugbounty.html is redirected to https://www.fastmail.com/about/bugbounty/
