### PR TITLE
chore: use import syntax in rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,8 @@
-const fs = require('fs');
-const babel = require('@rollup/plugin-babel').babel;
-const nodeResolve = require('@rollup/plugin-node-resolve').nodeResolve;
-const replace = require('@rollup/plugin-replace');
-const { terser } = require('rollup-plugin-terser');
+import fs from 'fs';
+import { babel } from '@rollup/plugin-babel';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import replace from '@rollup/plugin-replace';
+import { terser } from 'rollup-plugin-terser';
 
 const env = process.env.NODE_ENV;
 const isProd = env === 'production';


### PR DESCRIPTION
This PR changes `rollup.config.js` to use `import` syntax.

### Background & Context

The official document uses `import` syntax.

e.g. https://rollupjs.org/guide/en/#using-output-plugins