### PR TITLE
chore: fix allowCustomizedBuiltInElements value in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ var clean = DOMPurify.sanitize(
         CUSTOM_ELEMENT_HANDLING: {
             tagNameCheck: /^foo-/, // allow all tags starting with "foo-"
             attributeNameCheck: /baz/, // allow all attributes containing "baz"
-            allowCustomizedBuiltInElements: false, // customized built-ins are allowed
+            allowCustomizedBuiltInElements: false, // no customized built-ins allowed
         },
     }
 ); // <foo-bar baz="foobar"></foo-bar><div is=""></div>

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ var clean = DOMPurify.sanitize(
         CUSTOM_ELEMENT_HANDLING: {
             tagNameCheck: /^foo-/, // allow all tags starting with "foo-"
             attributeNameCheck: /baz/, // allow all attributes containing "baz"
-            allowCustomizedBuiltInElements: false, // no customized built-ins allowed
+            allowCustomizedBuiltInElements: true, // customized built-ins are allowed
         },
     }
 ); // <foo-bar baz="foobar"></foo-bar><div is=""></div>


### PR DESCRIPTION
## Summary

The value in readme seems to be incorrect. The comment above informs us that if we pass false as a value, then no customized built-ins are allowed.

## Background & Context



## Tasks

<!-- Add tasks to give a quick overview for QA and reviewers -->

- xxxx
- xxxx
- xxxx

## Dependencies

<!-- If there are any dependencies on PRs or API work then list them here. -->

