### PR TITLE
Fix Trusted Types Sink violation with empty input and NAMESPACE

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -844,7 +844,9 @@ function createDOMPurify(window = getGlobal()) {
     if (!doc || !doc.documentElement) {
       doc = implementation.createDocument(NAMESPACE, 'template', null);
       try {
-        doc.documentElement.innerHTML = IS_EMPTY_INPUT ? emptyHTML : dirtyPayload;
+        doc.documentElement.innerHTML = IS_EMPTY_INPUT
+          ? emptyHTML
+          : dirtyPayload;
       } catch (_) {
         // Syntax error if dirtyPayload is invalid xml
       }

--- a/src/purify.js
+++ b/src/purify.js
@@ -844,7 +844,7 @@ function createDOMPurify(window = getGlobal()) {
     if (!doc || !doc.documentElement) {
       doc = implementation.createDocument(NAMESPACE, 'template', null);
       try {
-        doc.documentElement.innerHTML = IS_EMPTY_INPUT ? '' : dirtyPayload;
+        doc.documentElement.innerHTML = IS_EMPTY_INPUT ? emptyHTML : dirtyPayload;
       } catch (_) {
         // Syntax error if dirtyPayload is invalid xml
       }


### PR DESCRIPTION
Use TrustedHTML instead of raw string when assigning empty string to Element.innerHTML sink. This should fix #747 . 
