### PR TITLE
add tag mprescripts to mathMl

### DIFF
--- a/src/tags.js
+++ b/src/tags.js
@@ -254,7 +254,7 @@ export const mathMl = freeze([
   'mtr',
   'munder',
   'munderover',
-  'mprescripts'
+  'mprescripts',
 ]);
 
 // Similarly to SVG, we want to know all MathML elements,

--- a/src/tags.js
+++ b/src/tags.js
@@ -254,6 +254,7 @@ export const mathMl = freeze([
   'mtr',
   'munder',
   'munderover',
+  'mprescripts'
 ]);
 
 // Similarly to SVG, we want to know all MathML elements,


### PR DESCRIPTION
## Summary

DOMPurify now removes the <mprescripts/> . tag
Causes the formula part of the CKEditor library to display an error

## Background & Context

correctly display CKEditor's Math formula

## Tasks

  add 'mprescripts' to mathML

- use formula in ckeditor

## Dependencies

exam 
 -input : "<p><math xmlns=\"http://www.w3.org/1998/Math/MathML\" class=\"wrs_chemistry\"><mmultiscripts><mi mathvariant=\"normal\">P</mi><mprescripts/><mn>200</mn><mn>190</mn></mmultiscripts></math></p>\n"

-output: "<p><math xmlns=\"http://www.w3.org/1998/Math/MathML\" class=\"wrs_chemistry\"><mmultiscripts><mi mathvariant=\"normal\">P</mi><mn>200</mn><mn>190</mn></mmultiscripts></math></p>\n"


- [x] Resolved dependency
- [x] Open dependency
