### PR TITLE
console warn fallback for <b> when run with Happydom

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -175,8 +175,7 @@ function lookupGetter(object, prop) {
     object = getPrototypeOf(object);
   }
 
-  function fallbackValue(element) {
-    console.warn('fallback value for', element);
+  function fallbackValue() {
     return null;
   }
 


### PR DESCRIPTION
## Summary

console.warn(element) is displaying a lot of stuff, in some context like HappyDom this displaying a lot of stuff because a recursive console output of the entire Dom.

## Background & Context

I was thinking of the other solutions
* Change the way of displaying a element in Happydom
* Remove the display of the element in the warn

## Tasks

- Could someone give me some context when this fallback function is called
  `fallback value for <b>by SMS</b>` when calling `DOMPurify.sanitize('The patient will receive a link <b>by SMS</b> to join the video consultation')` so why `<b>by SMS</b>` will be an element considered as a fallback ?

https://github.com/cure53/DOMPurify/blob/756cec35240cefe261aab06be1e0a7a1e66a6b19/src/purify.js#L114-L120

Could be Happydom not implementing the same way the API for `<b>` ?

As now it seems Dompurify doesn't support Happydom so might be an upstream issue in Happydom itself.
