### PR TITLE
Update attrs.js

### DIFF
--- a/src/attrs.js
+++ b/src/attrs.js
@@ -108,6 +108,7 @@ export const html = freeze([
   'valign',
   'value',
   'width',
+  'wrap',
   'xmlns',
   'slot',
 ]);


### PR DESCRIPTION
Add the `wrap` HTML attribute per issue [#925](https://github.com/cure53/DOMPurify/issues/925).

## Summary

It looks like DOMPurify is removing the [`wrap`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#wrap) attribute on elements like `<textarea>`. Since this has no security-related issues, we can safely add it.