### PR TITLE
docs(README.md): correct hook name in example and remove misleading comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ After sanitizing your markup, you can also have a look at the property `DOMPurif
 
 DOMPurify technically also works server-side with Node.js. Our support strives to follow the [Node.js release cycle](https://nodejs.org/en/about/releases/).
 
-Running DOMPurify on the server requires a DOM to be present, which is probably no surprise. Usually, [jsdom](https://github.com/jsdom/jsdom) is the tool of choice and we **strongly recommend** to use the latest version of _jsdom_. 
+Running DOMPurify on the server requires a DOM to be present, which is probably no surprise. Usually, [jsdom](https://github.com/jsdom/jsdom) is the tool of choice and we **strongly recommend** to use the latest version of _jsdom_.
 
 Why? Because older versions of _jsdom_ are known to be buggy in ways that result in XSS _even if_ DOMPurify does everything 100% correctly. There are **known attack vectors** in, e.g. _jsdom v19.0.0_ that are fixed in _jsdom v20.0.0_ - and we really recommend to keep _jsdom_ up to date because of that.
 
@@ -369,11 +369,10 @@ _Example_:
 
 ```js
 DOMPurify.addHook(
-  'beforeSanitizeElements',
+  'uponSanitizeAttribute',
   function (currentNode, hookEvent, config) {
-    // Do something with the current node and return it
-    // You can also mutate hookEvent (i.e. set hookEvent.forceKeepAttr = true)
-    return currentNode;
+    // Do something with the current node
+    // You can also mutate hookEvent for current node (i.e. set hookEvent.forceKeepAttr = true)
   }
 );
 ```

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ DOMPurify.addHook(
   function (currentNode, hookEvent, config) {
     // Do something with the current node
     // You can also mutate hookEvent for current node (i.e. set hookEvent.forceKeepAttr = true)
+    // For other than 'uponSanitizeAttribute' hook types hookEvent equals to null
   }
 );
 ```


### PR DESCRIPTION
## Summary

this pull request changes hook usage example 

## Background & Context

now hookEvent is passed **only** for `uponSanitizeAttribute` hook.
currently there is misleading example of hook usage, where the `beforeSanitizeElements` hook is used.

in order to avoid misunderstandings and simplify life for next users of lib, let's correct this mistake.
