### PR TITLE
fix(typo): found by `codespell`

### DIFF
--- a/src/purify.js
+++ b/src/purify.js
@@ -1034,7 +1034,7 @@ function createDOMPurify(window = getGlobal()) {
       return true;
     }
 
-    /* Remove any ocurrence of processing instructions */
+    /* Remove any occurrence of processing instructions */
     if (currentNode.nodeType === NODE_TYPE.progressingInstruction) {
       _forceRemove(currentNode);
       return true;

--- a/test/fixtures/expect.mjs
+++ b/test/fixtures/expect.mjs
@@ -191,7 +191,7 @@ export default [
       "payload": "<image name=body><image name=adoptNode>@mmrupp<image name=firstElementChild><svg onload=alert(1)>",
       "expected": "<img><img>@mmrupp<img><svg></svg>"
   }, {
-      "title": "Special esacpes in protocol handler for XSS in Blink",
+      "title": "Special escapes in protocol handler for XSS in Blink",
       "payload": "<a href=\"\u0001java\u0003script:alert(1)\">@shafigullin<a>",
       "expected": "<a>@shafigullin</a><a></a>"
   }, {
@@ -879,11 +879,11 @@ export default [
           "<math></math>"
       ]
   }, {
-      "title": "Tests against additonal problems regarding HTML inside MathML 1/2",
+      "title": "Tests against additional problems regarding HTML inside MathML 1/2",
       "payload": "<math><mtext><h1><a><h6></a></h6><mglyph><svg><mtext><style><a title=\"</style><img src onerror='alert(1)'>\"></style></h1>",
       "expected": "<math><mtext><h1><a></a><h6><a></a></h6></h1></mtext></math>"
   }, {
-      "title": "Tests against additonal problems regarding HTML inside MathML 2/2",
+      "title": "Tests against additional problems regarding HTML inside MathML 2/2",
       "payload": "<!-- more soon -->",
       "expected": ""
   },   {

--- a/test/karma.custom-launchers.config.js
+++ b/test/karma.custom-launchers.config.js
@@ -206,7 +206,7 @@ const getRandomBrowser = () => sample(getAllBrowsers());
  * - Whenever on a PR we only want to probe test with Firefox
  * - Whenever we are on the most recent node version on GitHub Actions we test via BrowserStack
  * - If none of the prior mentioned holds we assume to be running local and respect the passed
- *   in borwsers argv
+ *   in browsers argv
  */
 const shouldProbeOnly = argv.shouldProbeOnly === 'true';
 const shouldTestOnBrowserStack = argv.shouldTestOnBrowserStack === 'true';

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -1124,9 +1124,9 @@
         assert.equal(DOMPurify.removed.length, 0);
       }
     );
-    // Tests to make sure that the node scanning feature delivers acurate results on all browsers
+    // Tests to make sure that the node scanning feature delivers accurate results on all browsers
     QUnit.test(
-      'DOMPurify should deliver acurate results when sanitizing nodes 1',
+      'DOMPurify should deliver accurate results when sanitizing nodes 1',
       function (assert) {
         var clean = DOMPurify.sanitize(document.createElement('td'));
         assert.equal(clean, '<td></td>');
@@ -1443,7 +1443,7 @@
         ALLOWED_URI_REGEXP: /test\.com/i
       }), '<img src="https://test.com">');
 
-      // ensure that the previous regexp does not affect future santize calls
+      // ensure that the previous regexp does not affect future sanitize calls
       assert.equal(DOMPurify.sanitize(dirty), expected);
     });
     QUnit.test(
@@ -1588,7 +1588,7 @@
       }
     );
     QUnit.test(
-      'Test for less agressive mXSS handling, See #369',
+      'Test for less aggressive mXSS handling, See #369',
       function (assert) {
         var config = {
           FORBID_TAGS: ['svg', 'math'],


### PR DESCRIPTION
## Summary

Fix typos found in comments and test descriptions.

## Background & Context

Run codespell.

