### PR TITLE
fix(types): export `Config` type from package

### DIFF
--- a/dist/purify.cjs.d.ts
+++ b/dist/purify.cjs.d.ts
@@ -396,6 +396,6 @@ type WindowLike = Pick<typeof globalThis, 'DocumentFragment' | 'HTMLTemplateElem
     trustedTypes?: typeof window.trustedTypes;
 };
 
-export { type Hook, type HookName, type RemovedAttribute, type RemovedElement, type UponSanitizeAttributeHook, type UponSanitizeAttributeHookEvent, type UponSanitizeElementHook, type UponSanitizeElementHookEvent, type WindowLike };
+export { type Config, type Hook, type HookName, type RemovedAttribute, type RemovedElement, type UponSanitizeAttributeHook, type UponSanitizeAttributeHookEvent, type UponSanitizeElementHook, type UponSanitizeElementHookEvent, type WindowLike };
 
 export = _default;

--- a/dist/purify.es.d.mts
+++ b/dist/purify.es.d.mts
@@ -396,4 +396,4 @@ type WindowLike = Pick<typeof globalThis, 'DocumentFragment' | 'HTMLTemplateElem
     trustedTypes?: typeof window.trustedTypes;
 };
 
-export { type Hook, type HookName, type RemovedAttribute, type RemovedElement, type UponSanitizeAttributeHook, type UponSanitizeAttributeHookEvent, type UponSanitizeElementHook, type UponSanitizeElementHookEvent, type WindowLike, _default as default };
+export { type Config, type Hook, type HookName, type RemovedAttribute, type RemovedElement, type UponSanitizeAttributeHook, type UponSanitizeAttributeHookEvent, type UponSanitizeElementHook, type UponSanitizeElementHookEvent, type WindowLike, _default as default };

--- a/src/purify.ts
+++ b/src/purify.ts
@@ -25,6 +25,8 @@ import {
   objectHasOwnProperty,
 } from './utils.js';
 
+export type { Config } from './config';
+
 declare const VERSION: string;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType


### PR DESCRIPTION
## Summary

This PR exports the `Config` type from DOMPurify, so that people can do:

```ts
import type {Config} from 'dompurify';

// or
type Config = import('dompurify').Config;
```

## Background & Context

This is to more closely match [@types/dompurify][1], which allows it, to make migration easier for any TypeScript users that currently use `@types/dompurify`.

[1]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a0058c8132907c88b6e4d3dd0f4103f799deb732/types/dompurify/index.d.ts#L59

## Tasks

<!-- Add tasks to give a quick overview for QA and reviewers -->

N/A

## Dependencies

<!-- If there are any dependencies on PRs or API work then list them here. -->

N/A
