### PR TITLE
Update CUSTOM_ELEMENT regexp to support custom elements with colon into the tag.

### DIFF
--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -14,4 +14,4 @@ export const ATTR_WHITESPACE = seal(
   /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g // eslint-disable-line no-control-regex
 );
 export const DOCTYPE_NAME = seal(/^html$/i);
-export const CUSTOM_ELEMENT = seal(/^[a-z][.\w]*(-[.\w]+)+$/i);
+export const CUSTOM_ELEMENT = seal(/^[a-z][.\w]*([-|:][.\w]+)+$/i);


### PR DESCRIPTION
I need to support custom elements that have colon into the tag definition. Example:
<app:custom-element>...</app:custom-element>