### PR TITLE
fix: ignore export assign cannot be used in module TS error, fixes #1018

### DIFF
--- a/dist/purify.cjs.d.ts
+++ b/dist/purify.cjs.d.ts
@@ -398,4 +398,5 @@ type WindowLike = Pick<typeof globalThis, 'DocumentFragment' | 'HTMLTemplateElem
 
 export { type Config, type Hook, type HookName, type RemovedAttribute, type RemovedElement, type UponSanitizeAttributeHook, type UponSanitizeAttributeHookEvent, type UponSanitizeElementHook, type UponSanitizeElementHookEvent, type WindowLike };
 
+// @ts-ignore
 export = _default;

--- a/scripts/fix-cjs-types.js
+++ b/scripts/fix-cjs-types.js
@@ -22,7 +22,7 @@ const path = require('node:path');
   // Append `export = _default;` to match the
   // `module.exports = DOMPurify` statement
   // that Rollup creates.
-  fixed += '\nexport = _default;\n';
+  fixed += '\n// @ts-ignore\nexport = _default;\n';
 
   await fs.writeFile(fileName, fixed);
 })().catch((ex) => {


### PR DESCRIPTION
fixes #1018

## Summary

Fixes issue #1018 by simply ignoring the TypeScript error since the TS error has no negative effect whatsoever on the functionality of these types. This makes TypeScript and "Are the Types Wrong" both happy and everything is back to normal and we can get back to work (finally).

The quick explanation is that sometime even when using ESM imports, CJS types exports get picked up (depending on the users tsconfig module resolutions) and `export = ...` is a TypeScript error, but we can easily patch it by ignoring it. 

![image](https://github.com/user-attachments/assets/4816846b-4e0e-4a0f-8910-367873973c3b)


## Background & Context

I found this article [Default exports in CommonJS libraries](https://blog.andrewbran.ch/default-exports-in-commonjs-libraries/) which explains why `export = _default` was patched in the first place. However this gives a TypeScript error in some cases (depending on your tsconfig module resolutions and other configs), this error can simply be ignored altogether because the types still work correctly, the error when active though will block a TypeScript build and ignoring the error will let us continue with our build. 

![image](https://github.com/user-attachments/assets/6a18480f-b75d-4424-ae91-e953c7f1fe81)

## Tasks

Simply modified the existing `fix-cjs-types.js` script, run a build.

This also keeps "Are the Types Wrong" happy since nothing really changed for the types themselves, so all is good.

![image](https://github.com/user-attachments/assets/f023c873-2df5-45a0-a2fc-577b5bd50e3b)


## Dependencies

<!-- If there are any dependencies on PRs or API work then list them here. -->

- [x] Resolved dependency
- [ ] Open dependency
