### PR TITLE
Moved the "import" exports to be first

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   "types": "./dist/purify.cjs.d.ts",
   "exports": {
     ".": {
-      "require": {
-        "types": "./dist/purify.cjs.d.ts",
-        "default": "./dist/purify.cjs.js"
-      },
       "import": {
         "types": "./dist/purify.es.d.mts",
         "default": "./dist/purify.es.mjs"
+      },
+      "default": {
+        "types": "./dist/purify.cjs.d.ts",
+        "default": "./dist/purify.cjs.js"
       }
     }
   },


### PR DESCRIPTION
## Summary

Moved the "import" conditional export to be defined first.

## Background & Context

Conditional exports are processed in order:

> Within the ["exports"](https://nodejs.org/api/packages.html#exports) object, key order is significant. During condition matching, earlier entries have higher priority and take precedence over later entries. The general rule is that conditions should be from most specific to least specific in object order.
> 
> https://nodejs.org/api/packages.html#conditional-exports

As far as I understand, this means the "imports" should be defined first so that it takes precedence over "require" or "default".

Thank you @ghiscoding for pointing this out in https://github.com/cure53/DOMPurify/issues/1018#issue-2653000713.

I've also changed "require" to "default" so that it's the catch-all fallback.

## Tasks

N/A

## Dependencies

 N/A
