### PR TITLE
fix: mark createDOMPurify param as optional

### DIFF
--- a/dist/purify.cjs.d.ts
+++ b/dist/purify.cjs.d.ts
@@ -206,9 +206,9 @@ declare const _default: DOMPurify;
 
 interface DOMPurify {
     /**
-     * Creates a DOMPurify instance using the given window-like object.
+     * Creates a DOMPurify instance using the given window-like object. Defaults to `window`.
      */
-    (root: WindowLike): DOMPurify;
+    (root?: WindowLike): DOMPurify;
     /**
      * Version label, exposed for easier checks
      * if DOMPurify is up to date or not

--- a/dist/purify.es.d.mts
+++ b/dist/purify.es.d.mts
@@ -206,9 +206,9 @@ declare const _default: DOMPurify;
 
 interface DOMPurify {
     /**
-     * Creates a DOMPurify instance using the given window-like object.
+     * Creates a DOMPurify instance using the given window-like object. Defaults to `window`.
      */
-    (root: WindowLike): DOMPurify;
+    (root?: WindowLike): DOMPurify;
     /**
      * Version label, exposed for easier checks
      * if DOMPurify is up to date or not

--- a/src/purify.ts
+++ b/src/purify.ts
@@ -1679,9 +1679,9 @@ export default createDOMPurify();
 
 export interface DOMPurify {
   /**
-   * Creates a DOMPurify instance using the given window-like object.
+   * Creates a DOMPurify instance using the given window-like object. Defaults to `window`.
    */
-  (root: WindowLike): DOMPurify;
+  (root?: WindowLike): DOMPurify;
 
   /**
    * Version label, exposed for easier checks


### PR DESCRIPTION
## Summary

this PR properly marks the createDOMPurify/DOMPurify ctor param as optional, since it has a default defined. it also documents said default.

## Background & Context

this broke my build when updating ^^
thanks for taking the time to add types tho, one less @types package :)

## Tasks

none

## Dependencies

none
