### PR TITLE
chore(package.json): add `purify.js` and `purify.min.js` to exports as targetable modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
         "types": "./dist/purify.cjs.d.ts",
         "default": "./dist/purify.cjs.js"
       }
-    }
+    },
+    "./purify.min.js": "./dist/purify.min.js",
+    "./purify.js": "./dist/purify.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
<!-- Explain this change, e.g. "this pull request [implements, fixes, changes]...". -->
This PR is per discussions had in the issue:
- https://github.com/cure53/DOMPurify/issues/1050

<br />

Adds `purify.js` and minified `purify.min.js` to the package.json **exports** field, allowing for each script to be called as it was prior to DOMPurify v3.2.0. 

DOMPurify was migrated over to utilizing exports in commit `faf296da9b412d93023dde1c8f86599cb7b13beb` and is provided in the link below:

- https://github.com/cure53/DOMPurify/commit/faf296da9b412d93023dde1c8f86599cb7b13beb#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R29-R41

```json
  "exports": {
    ".": {
      "require": {
        "types": "./dist/purify.cjs.d.ts",
        "default": "./dist/purify.cjs.js"
      },
      "import": {
        "types": "./dist/purify.es.d.mts",
        "default": "./dist/purify.es.mjs"
      }
    }
  },
```

DOMPurify v3.1.7 is the last version that utilized the old `main` field without `exports`.

This PR simply allows for the above two files to be targeted. The new entries were added as their own named exports, and do not override the defaults configured by DOMPurify; so existing users will have no issues after updating, all imports will remain the same.

Tested this on both a project utilizing webpack (all existing DOMPurify calls continued to work as normal), and also tested on a new project not utilizing Webpack, and only using the existing exports and all functionality continued to work.

As we know, `exports` was introduced in Node `v12.7.0` as a succession to the older `main` functionality, allowing developers to control that aspects of a library can be called.

With the edits made in the PR, webpack behaves as it originally did where each file can now be targeted and loaded when desired.

<br />

---

<br />

## Background & Context

<!-- Briefly outline why this PR was needed, a minimal context, culminating in your implementation. -->

At present, using DOMpurify in combination with webpack 5. To control the dev and production environment, being able to use an alias, and to decide when to minify and when to not, we would need access to each of the two files individually.

```
{
	alias: {
	    jquery: `jquery/dist/jquery${bDevMode? '' : '.min'}.js`,
	    dompurify: `dompurify/dist/purify${bDevMode? '' : '.min'}.js`,
	}
}
```

<br />

Without this change, webpack does not build, and throws a failure error:

> Package path ./dist/purify.min.js is not exported from package node_modules\dompurify (see exports field in node_modules\dompurify\package.json)

To temporarily circumvent this issue, we had to do away with calling the uncompressed and minified files all-together, which means we cannot specify which files get minified and which ones do not.

According to the webpack documentation, webpack has a way to ignore the export fields by defining `exportsFields: []` in the `webpack.config.js` file, but it is global only. It cannot be controlled based on each alias. You either get all or nothing. And that would kill many other packages using exports.

```
    resolve: {
		exportsFields: [],
		alias: {
		    jquery: `jquery/dist/jquery${bDevMode? '' : '.min'}.js`,
		    dompurify: `dompurify/dist/purify${bDevMode? '' : '.min'}.js`,
		}
	}
```

Webpack's documentation makes note of the behavior it takes in regards to exports:

>As of version 5.94.0, webpack's behavior has been updated to align with Node's behavior. It now selects the first valid path without attempting further resolutions and throws an error if the path cannot be resolved.

At the time of writing this, I am currently on webpack `5.97.1`.

<br />

---

<br />

## Tasks

<!-- Add tasks to give a quick overview for QA and reviewers -->

- Install PR
- Import DOMPurify
- Using any of the existing methods should continue to work (ie: `DOMPurify.sanitize`)

For webpack users, they can configure DOMPurify as a normal alias within `webpack.config.js`

```
resolve: {
    alias: {
        dompurify: `dompurify/dist/purify${bDevMode ? '' : '.min'}.js`,
    }
}
```

## Dependencies

<!-- If there are any dependencies on PRs or API work then list them here. -->

- [x] Resolved dependency
- [ ] Open dependency
