### PR TITLE
tests: DOMPurify custom window test improvement

### DIFF
--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -859,15 +859,24 @@
       assert.strictEqual(DOMPurify({}).isSupported, false);
       assert.strictEqual(DOMPurify({}).sanitize, undefined);
       assert.strictEqual(
-        typeof DOMPurify({ document: 'not really a document' }).version,
+        typeof DOMPurify({
+          document: 'not really a document',
+          Element: window.Element,
+        }).version,
         'string'
       );
       assert.strictEqual(
-        DOMPurify({ document: 'not really a document' }).isSupported,
+        DOMPurify({
+          document: 'not really a document',
+          Element: window.Element,
+        }).isSupported,
         false
       );
       assert.strictEqual(
-        DOMPurify({ document: 'not really a document' }).sanitize,
+        DOMPurify({
+          document: 'not really a document',
+          Element: window.Element,
+        }).sanitize,
         undefined
       );
       assert.strictEqual(
@@ -881,6 +890,14 @@
       assert.strictEqual(
         DOMPurify({ document, Element: undefined }).sanitize,
         undefined
+      );
+      assert.strictEqual(
+        typeof DOMPurify({ document, Element: window.Element }).version,
+        'string'
+      );
+      assert.strictEqual(
+        typeof DOMPurify({ document, Element: window.Element }).sanitize,
+        'function'
       );
       assert.strictEqual(typeof DOMPurify(window).version, 'string');
       assert.strictEqual(typeof DOMPurify(window).sanitize, 'function');


### PR DESCRIPTION
## Summary

<!-- Explain this change, e.g. "this pull request [implements, fixes, changes]...". -->

1. Improved the "DOMPurify custom window" test to ensure that the `document` and `window.Element` are tested separately.
2. Increased the likelihood of the test failing if a new `window` property is required in the future, thereby reducing the risk of future `TypeError: Cannot read properties of undefined` errors.