### PR TITLE
chore(package.json): add `dist/purify.js` and `dist/purify.min.js` to exports as targetable modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
       }
     },
     "./purify.min.js": "./dist/purify.min.js",
-    "./purify.js": "./dist/purify.js"
+    "./purify.js": "./dist/purify.js",
+    "./dist/purify.min.js": "./dist/purify.min.js",
+    "./dist/purify.js": "./dist/purify.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

This pull request tries to solve a similar issue as described in: https://github.com/cure53/DOMPurify/issues/1050 and fixed in https://github.com/cure53/DOMPurify/pull/1053

In our case we are importing this lib via `dompurify/dist/purify.js`. Which fails with the recent versions of this lib since the `exports` field was introduced with this error message:
```
Error: Module not found: Error: Package path ./dist/purify.js is not exported from package node_modules/dompurify (see exports field in node_modules/dompurify/package.json)
```

## Background & Context

<!-- Briefly outline why this PR was needed, a minimal context, culminating in your implementation. -->
I won't go to much into details here as it is basically the same story as in https://github.com/cure53/DOMPurify/pull/1053.
This could probably also be solved by anyone using this lib by adapting the import of this lib from `dompurify/dist/purify.js` to `dompurify/purify.js`, but this way it would not require a change for anyone still using `dompurify/dist/purify.js`.

## Tasks

<!-- Add tasks to give a quick overview for QA and reviewers -->

- Install PR
- Import DOMPurify
- Using any of the existing methods should continue to work (ie: DOMPurify.sanitize)

## Dependencies

<!-- If there are any dependencies on PRs or API work then list them here. -->

- [x] Resolved dependency
- [ ] Open dependency
