### PR TITLE
fix(trusted-types): Use 'trusted-types/lib'

### DIFF
--- a/dist/purify.cjs.d.ts
+++ b/dist/purify.cjs.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="trusted-types" />
+/// <reference types="trusted-types/lib" />
 /*! @license DOMPurify 3.2.4 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.2.4/LICENSE */
 
 /**

--- a/dist/purify.cjs.d.ts
+++ b/dist/purify.cjs.d.ts
@@ -1,5 +1,6 @@
-/// <reference types="trusted-types/lib" />
 /*! @license DOMPurify 3.2.4 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.2.4/LICENSE */
+
+import { TrustedTypePolicy, TrustedHTML, TrustedTypesWindow } from 'trusted-types/lib';
 
 /**
  * Configuration to control DOMPurify behavior.
@@ -433,8 +434,7 @@ interface UponSanitizeAttributeHookEvent {
 type WindowLike = Pick<typeof globalThis, 'DocumentFragment' | 'HTMLTemplateElement' | 'Node' | 'Element' | 'NodeFilter' | 'NamedNodeMap' | 'HTMLFormElement' | 'DOMParser'> & {
     document?: Document;
     MozNamedAttrMap?: typeof window.NamedNodeMap;
-    trustedTypes?: typeof window.trustedTypes;
-};
+} & Pick<TrustedTypesWindow, 'trustedTypes'>;
 
 export { type Config, type DOMPurify, type DocumentFragmentHook, type ElementHook, type HookName, type NodeHook, type RemovedAttribute, type RemovedElement, type UponSanitizeAttributeHook, type UponSanitizeAttributeHookEvent, type UponSanitizeElementHook, type UponSanitizeElementHookEvent, type WindowLike };
 

--- a/dist/purify.es.d.mts
+++ b/dist/purify.es.d.mts
@@ -1,5 +1,6 @@
-/// <reference types="trusted-types/lib" />
 /*! @license DOMPurify 3.2.4 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.2.4/LICENSE */
+
+import { TrustedTypePolicy, TrustedHTML, TrustedTypesWindow } from 'trusted-types/lib';
 
 /**
  * Configuration to control DOMPurify behavior.
@@ -433,7 +434,6 @@ interface UponSanitizeAttributeHookEvent {
 type WindowLike = Pick<typeof globalThis, 'DocumentFragment' | 'HTMLTemplateElement' | 'Node' | 'Element' | 'NodeFilter' | 'NamedNodeMap' | 'HTMLFormElement' | 'DOMParser'> & {
     document?: Document;
     MozNamedAttrMap?: typeof window.NamedNodeMap;
-    trustedTypes?: typeof window.trustedTypes;
-};
+} & Pick<TrustedTypesWindow, 'trustedTypes'>;
 
 export { type Config, type DOMPurify, type DocumentFragmentHook, type ElementHook, type HookName, type NodeHook, type RemovedAttribute, type RemovedElement, type UponSanitizeAttributeHook, type UponSanitizeAttributeHookEvent, type UponSanitizeElementHook, type UponSanitizeElementHookEvent, type WindowLike, _default as default };

--- a/dist/purify.es.d.mts
+++ b/dist/purify.es.d.mts
@@ -1,4 +1,4 @@
-/// <reference types="trusted-types" />
+/// <reference types="trusted-types/lib" />
 /*! @license DOMPurify 3.2.4 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.2.4/LICENSE */
 
 /**

--- a/scripts/fix-types.js
+++ b/scripts/fix-types.js
@@ -7,7 +7,6 @@ const path = require('node:path');
   // Note that this script is intended to run on the type declaration file that is
   // output by Rollup, and not the type declaration file generated from TypeScript.
   await fixCjsTypes(path.resolve(__dirname, '../dist/purify.cjs.d.ts'));
-  await fixEsmTypes(path.resolve(__dirname, '../dist/purify.es.d.mts'));
 })().catch((ex) => {
   console.error(ex);
   process.exitCode = 1;
@@ -37,24 +36,5 @@ async function fixCjsTypes(fileName) {
   // for certain configurations, so add a `@ts-ignore` comment before it.
   fixed += '\n// @ts-ignore\nexport = _default;\n';
 
-  await fs.writeFile(fileName, addTrustedTypesReference(fixed));
-}
-
-/**
- * Fixes the ESM type declarations file.
- * @param {string} fileName
- */
-async function fixEsmTypes(fileName) {
-  let types = await fs.readFile(fileName, { encoding: 'utf-8' });
-  await fs.writeFile(fileName, addTrustedTypesReference(types));
-}
-
-function addTrustedTypesReference(types) {
-  // We need to tell TypeScript that we use the type declarations from
-  // `trusted-types` so that it ends up in our type declaration type).
-  // Without this, the references to trusted-types in the type declaration
-  // file can cause compilation errors for certain configurations. We use
-  // the '/lib' entrypoint to avoid modifying global scope, see:
-  // https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/trusted-types#library-usage
-  return `/// <reference types="trusted-types/lib" />\n${types}`;
+  await fs.writeFile(fileName, fixed);
 }

--- a/scripts/fix-types.js
+++ b/scripts/fix-types.js
@@ -53,6 +53,8 @@ function addTrustedTypesReference(types) {
   // We need to tell TypeScript that we use the type declarations from
   // `trusted-types` so that it ends up in our type declaration type).
   // Without this, the references to trusted-types in the type declaration
-  // file can cause compilation errors for certain configurations.
-  return `/// <reference types="trusted-types" />\n${types}`;
+  // file can cause compilation errors for certain configurations. We use
+  // the '/lib' entrypoint to avoid modifying global scope, see:
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/trusted-types#library-usage
+  return `/// <reference types="trusted-types/lib" />\n${types}`;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/indent */
 
+import type { TrustedTypePolicy } from 'trusted-types/lib';
+
 /**
  * Configuration to control DOMPurify behavior.
  */

--- a/src/purify.ts
+++ b/src/purify.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/indent */
 
+import type { TrustedHTML, TrustedTypesWindow } from 'trusted-types/lib';
 import type { Config, UseProfilesConfig } from './config';
 import * as TAGS from './tags.js';
 import * as ATTRS from './attrs.js';
@@ -2006,5 +2007,4 @@ export type WindowLike = Pick<
 > & {
   document?: Document;
   MozNamedAttrMap?: typeof window.NamedNodeMap;
-  trustedTypes?: typeof window.trustedTypes;
-};
+} & Pick<TrustedTypesWindow, 'trustedTypes'>;


### PR DESCRIPTION
## Summary

Replaces 'trusted-types' import with 'trusted-type/lib', as described at https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/trusted-types#library-usage.

## Background & Context

In a private project (apologies, I've so far been unable to reproduce the issue in a standalone example) I'm seeing seemingly-unrelated errors from TypeScript after updating to dompurify@v3. The errors all seem related to Redux usage. For example:

```bash
src/path/to/file.tsx:550:14 - error TS2554: Expected 1 arguments, but got 0.

550     dispatch(setCurrentConnection())
                 ~~~~~~~~~~~~~~~~~~~~
```

It's not obvious to me how trusted-types would affect Redux or other types, but the only two ways I've found to avoid the error were to (1) make this change to dompurify, or (2) to use `package.json#resolutions` to point to a non-existent folder and prevent the installation of `@type/trusted-types` in the first place. While `@type/trusted-types` is an optional dependency, Yarn currently doesn't provide a real way to prevent installation of a specific optional dependency.

## Tasks

I've tested this in my own project with `yarn link`, and it worked well, but I don't know what "compilation errors for certain configurations" refers to in `fix-types.js`, so perhaps some testing is needed to make sure my changes do not cause those same errors?

Thanks!