### PR TITLE
test: verify various typescript configurations

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,3 +43,5 @@ jobs:
           TEST_PROBE_ONLY: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/2.x' }}
           BS_USERNAME: ${{ secrets.BS_USERNAME }}
           BS_ACCESSKEY: ${{ secrets.BS_ACCESSKEY }}
+      - name: Verify TypeScript
+        run: npm run verify-typescript

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:jsdom": "cross-env NODE_ENV=test BABEL_ENV=rollup node test/jsdom-node-runner --dot",
     "test:karma": "cross-env NODE_ENV=test BABEL_ENV=rollup karma start test/karma.conf.js --log-level warn ",
     "test:ci": "cross-env NODE_ENV=test BABEL_ENV=rollup npm run test:jsdom && npm run test:karma -- --log-level error --reporters dots --single-run --shouldTestOnBrowserStack=\"${TEST_BROWSERSTACK}\" --shouldProbeOnly=\"${TEST_PROBE_ONLY}\"",
-    "test": "cross-env NODE_ENV=test BABEL_ENV=rollup npm run lint &&  npm run test:jsdom && npm run test:karma -- --browsers Chrome"
+    "test": "cross-env NODE_ENV=test BABEL_ENV=rollup npm run lint &&  npm run test:jsdom && npm run test:karma -- --browsers Chrome",
+    "verify-typescript": "node ./typescript/verify.js"
   },
   "main": "./dist/purify.cjs.js",
   "module": "./dist/purify.es.mjs",

--- a/typescript/commonjs-with-no-types/index.ts
+++ b/typescript/commonjs-with-no-types/index.ts
@@ -1,0 +1,4 @@
+import * as dompurify from 'dompurify';
+
+dompurify.sanitize('<p>');
+dompurify().sanitize('<p>');

--- a/typescript/commonjs-with-no-types/tsconfig.json
+++ b/typescript/commonjs-with-no-types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2015",
+    "typeRoots": ["types"]
+  }
+}

--- a/typescript/commonjs-with-no-types/types/readme.md
+++ b/typescript/commonjs-with-no-types/types/readme.md
@@ -1,0 +1,1 @@
+This simulates not having `@types/trusted-types` installed.

--- a/typescript/commonjs-with-specific-types/index.ts
+++ b/typescript/commonjs-with-specific-types/index.ts
@@ -1,0 +1,4 @@
+import * as dompurify from 'dompurify';
+
+dompurify.sanitize('<p>');
+dompurify().sanitize('<p>');

--- a/typescript/commonjs-with-specific-types/tsconfig.json
+++ b/typescript/commonjs-with-specific-types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2015",
+    "types": ["node"]
+  }
+}

--- a/typescript/commonjs/index.ts
+++ b/typescript/commonjs/index.ts
@@ -1,0 +1,4 @@
+import * as dompurify from 'dompurify';
+
+dompurify.sanitize('<p>');
+dompurify().sanitize('<p>');

--- a/typescript/commonjs/tsconfig.json
+++ b/typescript/commonjs/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2015"
+  }
+}

--- a/typescript/esm-with-no-types/index.ts
+++ b/typescript/esm-with-no-types/index.ts
@@ -1,0 +1,4 @@
+import dompurify from 'dompurify';
+
+dompurify.sanitize('<p>');
+dompurify().sanitize('<p>');

--- a/typescript/esm-with-no-types/package.json
+++ b/typescript/esm-with-no-types/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/typescript/esm-with-no-types/tsconfig.json
+++ b/typescript/esm-with-no-types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "typeRoots": ["types"]
+  }
+}

--- a/typescript/esm-with-no-types/types/readme.md
+++ b/typescript/esm-with-no-types/types/readme.md
@@ -1,0 +1,1 @@
+This simulates not having `@types/trusted-types` installed.

--- a/typescript/esm-with-specific-types/index.ts
+++ b/typescript/esm-with-specific-types/index.ts
@@ -1,0 +1,4 @@
+import dompurify from 'dompurify';
+
+dompurify.sanitize('<p>');
+dompurify().sanitize('<p>');

--- a/typescript/esm-with-specific-types/package.json
+++ b/typescript/esm-with-specific-types/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/typescript/esm-with-specific-types/tsconfig.json
+++ b/typescript/esm-with-specific-types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  }
+}

--- a/typescript/esm/index.ts
+++ b/typescript/esm/index.ts
@@ -1,0 +1,4 @@
+import dompurify from 'dompurify';
+
+dompurify.sanitize('<p>');
+dompurify().sanitize('<p>');

--- a/typescript/esm/package.json
+++ b/typescript/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/typescript/esm/tsconfig.json
+++ b/typescript/esm/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "bundler"
+  }
+}

--- a/typescript/nodenext/index.ts
+++ b/typescript/nodenext/index.ts
@@ -1,0 +1,4 @@
+import dompurify from 'dompurify';
+
+dompurify.sanitize('<p>');
+dompurify().sanitize('<p>');

--- a/typescript/nodenext/tsconfig.json
+++ b/typescript/nodenext/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "dompurify": "file:.."
+  }
+}

--- a/typescript/verify.js
+++ b/typescript/verify.js
@@ -1,0 +1,119 @@
+// @ts-check
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const ts = require('typescript');
+const { exec } = require('child_process');
+
+run().catch((ex) => {
+  console.error(ex);
+  process.exitCode = 1;
+});
+
+async function run() {
+  // Install node modules so that `dompurify` can be resolved.
+  process.stdout.write(`\x1b[30mInstalling node modules...\x1b[0m\n`);
+
+  await new Promise((resolve, reject) => {
+    exec('npm install --no-package-lock', { cwd: __dirname }, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(undefined);
+      }
+    });
+  });
+
+  process.stdout.write('\n');
+
+  let projects = await fs.readdir(__dirname, { withFileTypes: true });
+
+  for (let project of projects
+    .filter((x) => x.isDirectory())
+    .filter((x) => x.name !== 'node_modules')
+    .sort((a, b) => a.name.localeCompare(b.name))) {
+    await verify(project.name, path.join(__dirname, project.name));
+  }
+}
+
+/**
+ * Verifies that a TypeScript project compiles.
+ * @param {string} name The name of the project.
+ * @param {string} directory The project directory.
+ * @returns {Promise<void>}
+ */
+async function verify(name, directory) {
+  let line = `  ${name}...`;
+  process.stdout.write(line);
+
+  let diagnostics = await compile(path.join(directory, 'tsconfig.json'));
+  let success = diagnostics.length === 0;
+
+  process.stdout.write(
+    `\x1b[${line.length}D\x1b${success ? '[32m✔' : '[31mX'}\x1b[0m ${name}   \n`
+  );
+
+  if (!success) {
+    printDiagnostics(diagnostics);
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * Compiles a TypeScript project.
+ * @param {string} configFileName The file name of the TypeScript config file.
+ * @returns {Promise<ts.Diagnostic[]>} The diagnostics produced.
+ */
+async function compile(configFileName) {
+  let jsonParseResult = ts.parseConfigFileTextToJson(
+    configFileName,
+    await fs.readFile(configFileName, { encoding: 'utf8' })
+  );
+
+  if (!jsonParseResult.config && jsonParseResult.error) {
+    return [jsonParseResult.error];
+  }
+
+  let config = ts.parseJsonConfigFileContent(
+    jsonParseResult.config,
+    ts.sys,
+    path.dirname(configFileName)
+  );
+  if (config.errors.length > 0) {
+    return config.errors;
+  }
+
+  let program = ts.createProgram(config.fileNames, config.options);
+  let emitResult = program.emit(
+    undefined,
+    // Do not emit anything.
+    () => undefined
+  );
+
+  return ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+}
+
+/**
+ * Prints the diagnostics to stdout.
+ * @param {ts.Diagnostic[]} diagnostics The diagnostics to report.
+ */
+function printDiagnostics(diagnostics) {
+  diagnostics.forEach((diagnostic) => {
+    let message = '';
+
+    if (diagnostic.file && diagnostic.start) {
+      let start = diagnostic.file.getLineAndCharacterOfPosition(
+        diagnostic.start
+      );
+
+      message += ` ${diagnostic.file.fileName} (${start.line + 1},${
+        start.character + 1
+      })`;
+    }
+
+    message +=
+      ': ' + ts.flattenDiagnosticMessageText(diagnostic.messageText, '    \n');
+
+    process.stdout.write(`\x1b[30m    ${message}\x1b[0m\n`);
+  });
+}

--- a/typescript/verify.js
+++ b/typescript/verify.js
@@ -48,10 +48,13 @@ async function verify(name, directory) {
 
   let diagnostics = await compile(path.join(directory, 'tsconfig.json'));
   let success = diagnostics.length === 0;
+  let report = `\x1b${success ? '[32m✔' : '[31mX'}\x1b[0m`;
 
-  process.stdout.write(
-    `\x1b[${line.length}D\x1b${success ? '[32m✔' : '[31mX'}\x1b[0m ${name}   \n`
-  );
+  if (process.stdout.isTTY) {
+    process.stdout.write(`\x1b[${line.length}D${report} ${name}   \n`);
+  } else {
+    process.stdout.write(` ${report}\n`);
+  }
 
   if (!success) {
     printDiagnostics(diagnostics);


### PR DESCRIPTION
## Summary

This pull request adds an npm script called `verify-typescript` that will attempt to compile some TypeScript projects with different configurations that use DOMPurify.

## Background & Context

See #1035 and #1073. It's easy to make a change to the TypeScript declarations and verify that it works for one or more configurations, but end up breaking another configuration. The goal of this change is to have a set of known TypeScript configurations that work. If we discover that another configuration doesn't work, then we can add the configuration to these tests and then go about fixing the TypeScript declarations to support that configuration, while also verifying that whatever change is made doesn't break any other configurations that we know about.

The TypeScript code in each project is not meant to be comprehensive. It is just enough to confirm that you can import from `dompurify` and call the functions. 

- Importing `dompurify` verifies that the export is correct, and that the type declarations for `trusted-types` works alongside `dompurify`.
- Calling the functions verifies that the value imported from `dompurify` is a function that creates a new `DOMPurify` instance, and that it also defines the `sanitize` function.

There are currently seven scenarios:
1. A standard CommonJS build.
2. A CommonJS build that specifies specific `types` to include. Notably, `trusted-types` is not one of them (this was actually what caused https://github.com/cure53/DOMPurify/issues/1035#issuecomment-2497890304
3. A CommonJS build that specifies a `typeRoots` to simulate not having `@types/trusted-types` installed.
4. A standard ESM build.
5. An ESM build that specifies specific `types` to include (and, like the CommonJS one does not include `trusted-types`)
6. An ESM build that specifies a `typeRoots` to simulate not having `@types/trusted-types` installed.
7. A `moduleResolution` of `nodenext`.

All of these projects compile successfully, and I have tried applying the change from #1073 and confirmed that it does result in compilation failures. 🎉 


Example output when all succeed:
```
> npm run verify-typescript

> dompurify@3.2.4 verify-typescript
> node ./typescript/verify.js

Installing node modules...

✔ commonjs   
✔ commonjs-with-no-types   
✔ commonjs-with-specific-types   
✔ esm   
✔ esm-with-no-types   
✔ esm-with-specific-types   
✔ nodenext   
```

Example output when there are failures (in this case I applied the changes from #1073):
```
> npm run verify-typescript

> dompurify@3.2.4 verify-typescript
> node ./typescript/verify.js

Installing node modules...

✔ commonjs   
X commonjs-with-no-types   
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.cjs.d.ts (171,28): Cannot find name 'TrustedTypePolicy'.
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.cjs.d.ts (246,9): Cannot find name 'TrustedHTML'.
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.cjs.d.ts (436,34): Property 'trustedTypes' does not exist on type 'Window & typeof globalThis'.
X commonjs-with-specific-types   
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.cjs.d.ts (171,28): Cannot find name 'TrustedTypePolicy'.
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.cjs.d.ts (246,9): Cannot find name 'TrustedHTML'.
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.cjs.d.ts (436,34): Property 'trustedTypes' does not exist on type 'Window & typeof globalThis'.
✔ esm   
X esm-with-no-types   
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.es.d.mts (171,28): Cannot find name 'TrustedTypePolicy'.
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.es.d.mts (246,9): Cannot find name 'TrustedHTML'.
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.es.d.mts (436,34): Property 'trustedTypes' does not exist on type 'Window & typeof globalThis'.
X esm-with-specific-types   
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.es.d.mts (171,28): Cannot find name 'TrustedTypePolicy'.
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.es.d.mts (246,9): Cannot find name 'TrustedHTML'.
     C:/Code/GitHub/cure53/DOMPurify/dist/purify.es.d.mts (436,34): Property 'trustedTypes' does not exist on type 'Window & typeof globalThis'.
✔ nodenext   
```

## Tasks

N/A

## Dependencies

N/A
