### PR TITLE
fix: prettier windows end of line not lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
## Summary

Force end of line to be lf.

## Background & Context

Under Windows git uses auto mode for end of line usage. This results in lfcf which lint tool prettier prohibits.

## Tasks


- checkout repo on windows
- run lint

## Dependencies

mentioned in https://github.com/cure53/DOMPurify/issues/1182#issuecomment-3739935881
