### PR TITLE
fix: remove deprecated call `QUnit.load()`

### DIFF
--- a/test/jsdom-node-runner.js
+++ b/test/jsdom-node-runner.js
@@ -21,4 +21,4 @@ qunitTap(QUnit, (line) => {
 });
 
 const startQUnit = require('./jsdom-node');
-startQUnit().then(() => QUnit.load());
+startQUnit().then(() => {});


### PR DESCRIPTION
## Summary

Remove deprecated call `QUnit.load()`.

## Background & Context

This is no longer needed since QUnit 2.1.1, and the call to QUnit.load() is safe to remove. https://qunitjs.com/api/QUnit/load/

## Tasks

- run test
- deprecation warning should not be present

## Dependencies

fixes #1187

