### PR TITLE
remove dependency `lodash.sample`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "karma-firefox-launcher": "^2.1.2",
         "karma-qunit": "^4.1.2",
         "karma-rollup-preprocessor": "^7.0.8",
-        "lodash.sample": "^4.2.1",
         "minimist": "^1.2.6",
         "npm-run-all": "^4.1.5",
         "pre-commit": "^1.2.2",
@@ -6710,11 +6709,6 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.sample": {
-      "version": "4.2.1",
       "dev": true,
       "license": "MIT"
     },
@@ -15753,10 +15747,6 @@
     },
     "lodash.merge": {
       "version": "4.6.2",
-      "dev": true
-    },
-    "lodash.sample": {
-      "version": "4.2.1",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "karma-firefox-launcher": "^2.1.2",
     "karma-qunit": "^4.1.2",
     "karma-rollup-preprocessor": "^7.0.8",
-    "lodash.sample": "^4.2.1",
     "minimist": "^1.2.6",
     "npm-run-all": "^4.1.5",
     "pre-commit": "^1.2.2",

--- a/test/karma.custom-launchers.config.js
+++ b/test/karma.custom-launchers.config.js
@@ -1,4 +1,3 @@
-const sample = require('lodash.sample');
 const argv = require('minimist')(process.argv.slice(2));
 
 const customLaunchers = {
@@ -221,7 +220,11 @@ const customLaunchers = {
 };
 
 const getAllBrowsers = () => Object.keys(customLaunchers);
-const getRandomBrowser = () => sample(getAllBrowsers());
+const getRandomBrowser = () => {
+  const browsers = getAllBrowsers();
+  const randomIndex = Math.floor(Math.random() * browsers.length);
+  return browsers[randomIndex];
+};
 
 /**
  * Environment variables are passed into the script and the depth of testing


### PR DESCRIPTION
## Summary

Use native code instead of dependency `lodash.sample`.

## Background & Context

Dependency can be replaced with 3 lines of code. No need to keep dependency.

## Tasks

<!-- Add tasks to give a quick overview for QA and reviewers -->

- run test
