### PR TITLE
fix: engine requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,6 @@
         "typescript": "^5.6.3",
         "xo": "^0.54.1"
       },
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/package.json
+++ b/package.json
@@ -97,8 +97,12 @@
       "VERSION"
     ]
   },
-  "engines": {
-    "node": ">=20"
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=20",
+      "onFail": "warn"
+    }
   },
   "optionalDependencies": {
     "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
## Summary

`engines` requirements causes problems.

## Background & Context

The package is used to distribute finished builds that do not have any direct requirements for the node version used.

However, a modern nodejs environment is required for the build process. A different configuration is provided for this purpose: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines

## Tasks

- CI should go green
- thows warnings on outdated node versions if try to build
- no warning on other installs

## Dependencies

<!-- If there are any dependencies on PRs or API work then list them here. -->

fixes #1209
