### PR TITLE
fix: FORBID_TAGS must win over ADD_TAGS function predicate

### DIFF
--- a/src/purify.ts
+++ b/src/purify.ts
@@ -1116,11 +1116,12 @@ function createDOMPurify(window: WindowLike = getGlobal()): DOMPurify {
 
     /* Remove element if anything forbids its presence */
     if (
-      !(
+      FORBID_TAGS[tagName] ||
+      (!(
         EXTRA_ELEMENT_HANDLING.tagCheck instanceof Function &&
         EXTRA_ELEMENT_HANDLING.tagCheck(tagName)
       ) &&
-      (!ALLOWED_TAGS[tagName] || FORBID_TAGS[tagName])
+        !ALLOWED_TAGS[tagName])
     ) {
       /* Check if we have a custom element to handle */
       if (!FORBID_TAGS[tagName] && _isBasicCustomElement(tagName)) {


### PR DESCRIPTION
## Summary

This pull request fixes FORBID_TAGS being bypassed when ADD_TAGS is a function predicate. Mirrors the FORBID_ATTR early-exit pattern from c361baa.

## Background & Context

When `EXTRA_ELEMENT_HANDLING.tagCheck` is a function that returns `true`, the short-circuit `||` in the removal condition skips the `FORBID_TAGS` check entirely. The FORBID_ATTR fix at line 1214 already handles the equivalent case for attributes. This applies the same principle to tags.

The fix moves `FORBID_TAGS[tagName]` to an OR at the top of the condition, so the removal block is always entered for forbidden tags. The existing `!FORBID_TAGS[tagName]` guard on the custom element escape path (line 1127) and the `KEEP_CONTENT` logic are preserved.

## Tasks

- FORBID_TAGS wins over function-based ADD_TAGS
- KEEP_CONTENT behavior preserved (children survive when tag is removed)
- Custom element handling still respects FORBID_TAGS
- All existing tests pass

## Dependencies

- [x] No dependencies