### PR TITLE
fix: prevent ADD_ATTR/ADD_TAGS function leaking into subsequent array…

### DIFF
--- a/src/purify.ts
+++ b/src/purify.ts
@@ -635,14 +635,10 @@ function createDOMPurify(window: WindowLike = getGlobal()): DOMPurify {
       }
     }
 
-    /* Prevent function-based ADD_ATTR / ADD_TAGS from leaking across calls */
-    if (!objectHasOwnProperty(cfg, 'ADD_TAGS')) {
-      EXTRA_ELEMENT_HANDLING.tagCheck = null;
-    }
-
-    if (!objectHasOwnProperty(cfg, 'ADD_ATTR')) {
-      EXTRA_ELEMENT_HANDLING.attributeCheck = null;
-    }
+    /* Always reset function-based ADD_TAGS / ADD_ATTR checks to prevent
+     * leaking across calls when switching from function to array config */
+    EXTRA_ELEMENT_HANDLING.tagCheck = null;
+    EXTRA_ELEMENT_HANDLING.attributeCheck = null;
 
     /* Merge configuration parameters */
     if (cfg.ADD_TAGS) {

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -332,6 +332,62 @@
       );
     });
     QUnit.test(
+      'Config-Flag tests: ADD_TAGS function should not leak into subsequent array calls',
+      function (assert) {
+        // Step 1: Call with ADD_TAGS as a permissive function
+        DOMPurify.sanitize('<b>x</b>', {
+          ADD_TAGS: function () {
+            return true;
+          },
+        });
+        // Step 2: Call with ADD_TAGS as an array – should NOT allow iframe/object/embed
+        var out = DOMPurify.sanitize(
+          '<iframe src="https://evil.com"></iframe><object data="https://evil.com"></object><embed src="https://evil.com">',
+          { ADD_TAGS: ['custom-tag'] }
+        );
+        assert.ok(
+          !/<(iframe|object|embed)/i.test(out),
+          'ADD_TAGS function must not leak permissiveness into subsequent array-based calls: ' + out
+        );
+        // Step 3: Call with no ADD_TAGS – should also be clean
+        var out2 = DOMPurify.sanitize(
+          '<iframe src="https://evil.com"></iframe>'
+        );
+        assert.ok(
+          !/<iframe/i.test(out2),
+          'Default call after function-based ADD_TAGS must block iframe: ' + out2
+        );
+      }
+    );
+    QUnit.test(
+      'Config-Flag tests: ADD_ATTR function should not leak into subsequent array calls',
+      function (assert) {
+        // Step 1: Call with ADD_ATTR as a permissive function
+        DOMPurify.sanitize('<b>x</b>', {
+          ADD_ATTR: function () {
+            return true;
+          },
+        });
+        // Step 2: Call with ADD_ATTR as an array – should NOT allow javascript: URIs
+        var out = DOMPurify.sanitize(
+          '<a href="javascript:alert(1)">click</a>',
+          { ADD_ATTR: ['class'] }
+        );
+        assert.ok(
+          out.indexOf('javascript:') === -1,
+          'ADD_ATTR function must not leak permissiveness into subsequent array-based calls: ' + out
+        );
+        // Step 3: Call with no ADD_ATTR – should also be clean
+        var out2 = DOMPurify.sanitize(
+          '<a href="javascript:alert(1)">click</a>'
+        );
+        assert.ok(
+          out2.indexOf('javascript:') === -1,
+          'Default call after function-based ADD_ATTR must block javascript: URIs: ' + out2
+        );
+      }
+    );
+    QUnit.test(
       'Config-Flag tests: FORBID_CONTENTS + FORBID_TAGS',
       function (assert) {
         // FORBID_CONTENTS + FORBID_TAGS


### PR DESCRIPTION
When sanitize() is called with ADD_ATTR or ADD_TAGS as a function, the function reference is stored in EXTRA_ELEMENT_HANDLING. A subsequent call that passes ADD_ATTR/ADD_TAGS as an array did not clear the stored function because objectHasOwnProperty(cfg, 'ADD_ATTR') returned true, skipping the conditional reset.

The leaked function is evaluated before URI/tag checks, so a permissive function (returning true) lets dangerous attributes (e.g. javascript: URIs) or forbidden tags (e.g. iframe) through on later calls.

Fix: unconditionally reset tagCheck/attributeCheck to null on every _parseConfig() call, then only set them if the current config provides a function. This ensures no cross-call leakage.

Includes regression tests for both ADD_ATTR and ADD_TAGS leakage scenarios.

## Tasks

Test if the changes are correct and if they don't introduce new problems.