### PR TITLE
chore: include LICENSE-MPL in published npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "LICENSE-MPL"
   ],
   "xo": {
     "semicolon": true,


### PR DESCRIPTION
## Summary

This pull request fixes a package configuration issue by ensuring that the `LICENSE-MPL` file is correctly bundled and included in the final npm artifact upon publication.
Fixes #1434 

## Background & Context

DOMPurify is dual-licensed under `(MPL-2.0 OR Apache-2.0)`. While the standard `LICENSE` file is automatically grabbed and included by npm's default publishing behavior, `LICENSE-MPL` was being left out. 

Because the `package.json` explicitly defines a `files` array, any custom-named assets that aren't specified there (and aren't part of npm's automatic inclusion list) are excluded from the published package. This PR rectifies that so downstream users consuming the package via `node_modules` can properly access both license files.

## Tasks

- [x] Add `"LICENSE-MPL"` to the `"files"` array in `package.json`
- [x] Verify tarball contents locally using `npm pack --dry-run`
- [x] Ensure all linting and test suites pass successfully

## Dependencies

- [x] Resolved dependency
- [ ] Open dependency
